### PR TITLE
fix: restore CI after address refactor follow-ups

### DIFF
--- a/src/hooks/accounts/accounts.test.ts
+++ b/src/hooks/accounts/accounts.test.ts
@@ -1316,10 +1316,11 @@ describe("accounts", () => {
       test("useEditedComment has edited comment", async () => {
         const rendered2 = renderHook<any, any>(() => {
           const comment = useComment({ commentCid: "Qm..." });
-          const editedComment = useEditedComment({ comment });
-          return editedComment;
+          return { comment, ...useEditedComment({ comment }) };
         });
-        await waitFor(() => rendered2.result.current.editedComment);
+        const waitForEditedComment = testUtils.createWaitFor(rendered2);
+        await waitForEditedComment(() => rendered2.result.current.comment.cid === "Qm...");
+        await waitForEditedComment(() => rendered2.result.current.editedComment);
         expect(rendered2.result.current.editedComment).not.toBe(undefined);
         expect(
           rendered2.result.current.pendingEdits.spoiler ||
@@ -2292,10 +2293,10 @@ describe("accounts", () => {
 
       beforeEach(async () => {
         rendered = renderHook<any, any>(() => {
-          const { accountCommunities } = useAccountCommunities();
+          const { accountCommunities, state, error, errors } = useAccountCommunities();
           const account = useAccount();
           const { setAccount } = accountsActions;
-          return { accountCommunities, setAccount, account };
+          return { accountCommunities, state, error, errors, setAccount, account };
         });
         waitFor = testUtils.createWaitFor(rendered);
 
@@ -2382,7 +2383,7 @@ describe("accounts", () => {
       test("useAccountCommunities reflects in-flight community fetches", async () => {
         await waitFor(() => rendered.result.current.accountCommunities["community address 1"]);
         const { account, setAccount } = rendered.result.current;
-        const createCommunityOrig = account.plebbit.createCommunity;
+        const createCommunityOrig = Plebbit.prototype.createCommunity;
         const slowCommunity = await createCommunityOrig.call(account.plebbit, {
           address: "slow community address",
         });
@@ -2390,11 +2391,11 @@ describe("accounts", () => {
         const slowCommunityPromise = new Promise((resolve) => {
           resolveSlowCommunity = resolve;
         });
-        account.plebbit.createCommunity = vi.fn(async (options: any) => {
+        Plebbit.prototype.createCommunity = vi.fn(async function (options: any) {
           if (options.address === "slow community address") {
             return slowCommunityPromise;
           }
-          return createCommunityOrig.call(account.plebbit, options);
+          return createCommunityOrig.call(this, options);
         });
 
         try {
@@ -2418,19 +2419,19 @@ describe("accounts", () => {
           resolveSlowCommunity?.(slowCommunity);
           await waitFor(() => rendered.result.current.state === "succeeded");
         } finally {
-          account.plebbit.createCommunity = createCommunityOrig;
+          Plebbit.prototype.createCommunity = createCommunityOrig;
         }
       });
 
       test("useAccountCommunities propagates failed community fetches", async () => {
         await waitFor(() => rendered.result.current.accountCommunities["community address 1"]);
         const { account, setAccount } = rendered.result.current;
-        const createCommunityOrig = account.plebbit.createCommunity;
-        account.plebbit.createCommunity = vi.fn(async (options: any) => {
+        const createCommunityOrig = Plebbit.prototype.createCommunity;
+        Plebbit.prototype.createCommunity = vi.fn(async function (options: any) {
           if (options.address === "failing community address") {
             throw new Error("community fetch failed");
           }
-          return createCommunityOrig.call(account.plebbit, options);
+          return createCommunityOrig.call(this, options);
         });
 
         try {
@@ -2450,7 +2451,7 @@ describe("accounts", () => {
             "community fetch failed",
           );
         } finally {
-          account.plebbit.createCommunity = createCommunityOrig;
+          Plebbit.prototype.createCommunity = createCommunityOrig;
         }
       });
     });

--- a/src/hooks/accounts/accounts.ts
+++ b/src/hooks/accounts/accounts.ts
@@ -602,6 +602,7 @@ export function useEditedComment(options?: UseEditedCommentOptions): UseEditedCo
       "signer",
       "commentCid",
       "communityAddress",
+      "subplebbitAddress",
       "timestamp",
     ]);
 

--- a/src/stores/communities/communities-store.test.ts
+++ b/src/stores/communities/communities-store.test.ts
@@ -137,22 +137,36 @@ describe("communities store", () => {
     const address = "owner-retry-address";
     const createOrig = mockAccount.plebbit.createCommunity;
     const communitiesOrig = mockAccount.plebbit.communities;
+    const ownCommunitiesDescriptor = Object.getOwnPropertyDescriptor(
+      mockAccount.plebbit,
+      "communities",
+    );
     const resolvedCommunity = await createOrig.call(mockAccount.plebbit, { address });
-    mockAccount.plebbit.createCommunity = vi
-      .fn()
-      .mockRejectedValueOnce(new Error("owner create failed"))
-      .mockRejectedValueOnce(new Error("fetch create failed"))
-      .mockResolvedValueOnce(resolvedCommunity);
-    mockAccount.plebbit.communities = [...communitiesOrig, address];
+    try {
+      mockAccount.plebbit.createCommunity = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("owner create failed"))
+        .mockRejectedValueOnce(new Error("fetch create failed"))
+        .mockResolvedValueOnce(resolvedCommunity);
+      Object.defineProperty(mockAccount.plebbit, "communities", {
+        configurable: true,
+        get: () => [...communitiesOrig, address],
+      });
 
-    await expect(
-      communitiesStore.getState().addCommunityToStore(address, mockAccount),
-    ).rejects.toThrow("fetch create failed");
-    await communitiesStore.getState().addCommunityToStore(address, mockAccount);
+      await expect(
+        communitiesStore.getState().addCommunityToStore(address, mockAccount),
+      ).rejects.toThrow("fetch create failed");
+      await communitiesStore.getState().addCommunityToStore(address, mockAccount);
 
-    expect(communitiesStore.getState().communities[address]).toBeDefined();
-    mockAccount.plebbit.createCommunity = createOrig;
-    mockAccount.plebbit.communities = communitiesOrig;
+      expect(communitiesStore.getState().communities[address]).toBeDefined();
+    } finally {
+      mockAccount.plebbit.createCommunity = createOrig;
+      if (ownCommunitiesDescriptor) {
+        Object.defineProperty(mockAccount.plebbit, "communities", ownCommunitiesDescriptor);
+      } else {
+        delete (mockAccount.plebbit as any).communities;
+      }
+    }
   });
 
   test("addCommunityToStore throws generic Error when community is undefined without thrown error", async () => {

--- a/test/test-server/index.js
+++ b/test/test-server/index.js
@@ -67,7 +67,7 @@ const plebbitDataPath = getTmpFolderPath();
     const comment = await plebbit2.createComment({
       title: "comment title",
       content: "comment content",
-      communityAddress: signer.address,
+      subplebbitAddress: signer.address,
       signer,
       author: { address: signer.address },
     });


### PR DESCRIPTION
## Summary
- restore legacy `subplebbitAddress` exclusion in `useEditedComment`
- make the edited comment test wait for the fetched comment before asserting edit state
- fix the communities store retry test to override the `communities` getter safely and restore mocks reliably
- switch the test server comment creation back to `subplebbitAddress` for compatibility with the current plebbit schema

## Verification
- `yarn prettier`
- `yarn test`
- `yarn build`
- `yarn vitest run --config config/vitest.config.js --coverage.enabled --coverage.provider=istanbul --coverage.reporter=text --coverage.reporter=json-summary --coverage.reportsDirectory=./coverage` (passes)
- `node scripts/verify-hooks-stores-coverage.mjs` (fails on broader pre-existing repo coverage gaps outside this diff)
- `yarn test:server` (blocked locally: missing `kubo` binary in this environment)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Small but behavior-affecting change in `useEditedComment`’s edit-diffing plus updates to async/mocking patterns in tests; low production impact expected, but regressions would show up as incorrect edit-state UI.
> 
> **Overview**
> Restores `subplebbitAddress` to the set of non-edit properties filtered out by `useEditedComment`, preventing address-schema fields from being treated as user edits.
> 
> Stabilizes several CI-flaky tests: `useEditedComment` now waits for the base comment fetch before asserting edit state; `useAccountCommunities` tests mock `Plebbit.prototype.createCommunity` (with proper `this` binding) and assert propagated `state/error/errors`; and the communities-store retry test safely overrides the `plebbit.communities` getter with reliable cleanup.
> 
> Updates the test server to publish comments using `subplebbitAddress` again for current plebbit schema compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 68e0289739b0c17f40272fe9e7dd064697c01dc8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error state management for account operations with better visibility into operation status and error details.
  * Enhanced consistency in comment property handling and editing workflows.

* **Chores**
  * Internal test infrastructure refinements and mock handling improvements for greater reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->