### PR TITLE
fix(accounts): roll back failed optimistic comment edits

### DIFF
--- a/src/hooks/accounts/accounts.ts
+++ b/src/hooks/accounts/accounts.ts
@@ -600,6 +600,7 @@ export function useEditedComment(options?: UseEditedCommentOptions): UseEditedCo
     const nonEditPropertyNames = new Set([
       "author",
       "signer",
+      "clientId",
       "commentCid",
       "communityAddress",
       "subplebbitAddress",

--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -837,23 +837,33 @@ describe("accounts-actions", () => {
       expect(edits.length).toBeGreaterThan(0);
     });
 
-    test("publishCommentEdit rolls back optimistic edit after terminal challenge error", async () => {
+    test("publishCommentEdit awaits rollback before firing onError", async () => {
       const account = Object.values(accountsStore.getState().accounts)[0];
+      const accountId = accountsStore.getState().activeAccountId!;
       const origCreate = account.plebbit.createCommentEdit.bind(account.plebbit);
+      const deleteAccountEdit = vi.spyOn(accountsDatabase, "deleteAccountEdit");
       vi.spyOn(account.plebbit, "createCommentEdit").mockImplementation(async (opts: any) => {
         const publication = await origCreate(opts);
         vi.spyOn(publication, "publishChallengeAnswers").mockImplementation(async () => {
-          publication.emit(
-            "error",
-            new Error(
-              "Error from /lit/: CommentEditPubsubPublication is attempting to edit a comment while not being the original author of the comment",
-            ),
+          const error = new Error(
+            "Error from /lit/: CommentEditPubsubPublication is attempting to edit a comment while not being the original author of the comment",
           );
+          publication.emit("error", error);
+          publication.emit("error", error);
         });
         return publication;
       });
 
-      const onError = vi.fn();
+      let resolveOnError!: () => void;
+      const onErrorSeen = new Promise<void>((resolve) => {
+        resolveOnError = resolve;
+      });
+      const onError = vi.fn(async () => {
+        expect(accountsStore.getState().accountsEdits[accountId]?.["cid"]).toBeUndefined();
+        const persistedEdits = await accountsDatabase.getAccountEdits(accountId);
+        expect(persistedEdits["cid"]).toBeUndefined();
+        resolveOnError();
+      });
       await act(async () => {
         await accountsActions.publishCommentEdit({
           communityAddress: "sub.eth",
@@ -866,23 +876,25 @@ describe("accounts-actions", () => {
         });
       });
 
-      await new Promise((r) => setTimeout(r, 200));
+      await onErrorSeen;
 
-      const accountId = accountsStore.getState().activeAccountId!;
-      expect(onError).toHaveBeenCalled();
+      expect(deleteAccountEdit).toHaveBeenCalledTimes(1);
+      expect(onError).toHaveBeenCalledTimes(2);
       expect(accountsStore.getState().accountsEdits[accountId]?.["cid"]).toBeUndefined();
 
       const persistedEdits = await accountsDatabase.getAccountEdits(accountId);
       expect(persistedEdits["cid"]).toBeUndefined();
     });
 
-    test("publishCommentEdit rollback preserves older edits for the same comment", async () => {
+    test("publishCommentEdit rollback preserves older identical edits for the same comment", async () => {
       const account = Object.values(accountsStore.getState().accounts)[0];
+      const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);
       const existingEdit = {
         commentCid: "cid",
-        content: "older edit",
         communityAddress: "sub.eth",
+        deleted: true,
         timestamp: 1,
+        clientId: "existing-edit",
       };
       await accountsDatabase.addAccountEdit(account.id, existingEdit as any);
       accountsStore.setState(({ accountsEdits }) => ({
@@ -916,6 +928,7 @@ describe("accounts-actions", () => {
       });
 
       await new Promise((r) => setTimeout(r, 200));
+      nowSpy.mockRestore();
 
       const remainingStateEdits = accountsStore.getState().accountsEdits[account.id]?.["cid"];
       expect(remainingStateEdits).toHaveLength(1);
@@ -924,6 +937,51 @@ describe("accounts-actions", () => {
       const persistedEdits = await accountsDatabase.getAccountEdits(account.id);
       expect(persistedEdits["cid"]).toHaveLength(1);
       expect(persistedEdits["cid"][0]).toMatchObject(existingEdit);
+    });
+
+    test("publishCommentEdit keeps optimistic edit when a later error happens after challenge success", async () => {
+      setPlebbitJs(PlebbitJsMock);
+      await testUtils.resetDatabasesAndStores();
+      const account = Object.values(accountsStore.getState().accounts)[0];
+      const accountId = accountsStore.getState().activeAccountId!;
+      const origCreate = account.plebbit.createCommentEdit.bind(account.plebbit);
+      vi.spyOn(account.plebbit, "createCommentEdit").mockImplementation(async (opts: any) => {
+        const publication = await origCreate(opts);
+        const origPublishChallengeAnswers = publication.publishChallengeAnswers.bind(publication);
+        vi.spyOn(publication, "publishChallengeAnswers").mockImplementation(async (...args) => {
+          await origPublishChallengeAnswers(...args);
+          publication.emit("error", new Error("post-success error"));
+        });
+        return publication;
+      });
+
+      let resolveOnError!: () => void;
+      const onErrorSeen = new Promise<void>((resolve) => {
+        resolveOnError = resolve;
+      });
+      const onError = vi.fn(() => {
+        resolveOnError();
+      });
+
+      await act(async () => {
+        await accountsActions.publishCommentEdit({
+          communityAddress: "sub.eth",
+          commentCid: "cid",
+          deleted: true,
+          onChallenge: (challenge: any, publication: any) =>
+            publication.publishChallengeAnswers(["4"]),
+          onChallengeVerification: () => {},
+          onError,
+        });
+      });
+
+      await onErrorSeen;
+
+      const storedEdits = accountsStore.getState().accountsEdits[accountId]?.["cid"] || [];
+      expect(storedEdits).toHaveLength(1);
+      const persistedEdits = await accountsDatabase.getAccountEdits(accountId);
+      expect(persistedEdits["cid"]).toHaveLength(1);
+      expect(onError).toHaveBeenCalledTimes(1);
     });
 
     test("publishCommentModeration retries on challenge failure", async () => {

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -40,6 +40,7 @@ import {
   addShortAddressesToAccountComment,
 } from "./utils";
 import isEqual from "lodash.isequal";
+import { v4 as uuid } from "uuid";
 import utils from "../../lib/utils";
 
 // Active publish-session tracking for pending comments (Task 3)
@@ -122,6 +123,11 @@ const cleanupPublishSessionOnTerminal = (accountId: string, index: number) => {
   abandonedPublishKeys.delete(key);
 };
 
+const doesStoredAccountEditMatch = (storedAccountEdit: any, targetStoredAccountEdit: any) =>
+  storedAccountEdit?.clientId && targetStoredAccountEdit?.clientId
+    ? storedAccountEdit.clientId === targetStoredAccountEdit.clientId
+    : isEqual(storedAccountEdit, targetStoredAccountEdit);
+
 const sanitizeStoredAccountEdit = (storedAccountEdit: any) => {
   const sanitizedStoredAccountEdit = { ...storedAccountEdit };
   delete sanitizedStoredAccountEdit.signer;
@@ -156,7 +162,7 @@ const removeStoredAccountEditFromState = (
   const commentEdits = accountEdits[storedAccountEdit.commentCid] || [];
   let deletedEdit = false;
   const nextCommentEdits = commentEdits.filter((commentEdit) => {
-    if (!deletedEdit && isEqual(commentEdit, storedAccountEdit)) {
+    if (!deletedEdit && doesStoredAccountEditMatch(commentEdit, storedAccountEdit)) {
       deletedEdit = true;
       return false;
     }
@@ -1078,8 +1084,10 @@ export const publishCommentEdit = async (
   delete createCommentEditOptions.onChallengeVerification;
   delete createCommentEditOptions.onError;
   delete createCommentEditOptions.onPublishingStateChange;
-  const storedCreateCommentEditOptions =
-    normalizePublicationOptionsForStore(createCommentEditOptions);
+  const storedCreateCommentEditOptions = {
+    ...normalizePublicationOptionsForStore(createCommentEditOptions),
+    clientId: uuid(),
+  };
   const storedCommentEdit = sanitizeStoredAccountEdit(storedCreateCommentEditOptions);
 
   let commentEdit = backfillPublicationCommunityAddress(
@@ -1136,8 +1144,8 @@ export const publishCommentEdit = async (
         }
       },
     );
-    commentEdit.on("error", (error: Error) => {
-      void rollbackStoredCommentEdit();
+    commentEdit.on("error", async (error: Error) => {
+      await rollbackStoredCommentEdit();
       publishCommentEditOptions.onError?.(error, commentEdit);
     });
     // TODO: add publishingState to account edits

--- a/src/stores/accounts/accounts-database.test.ts
+++ b/src/stores/accounts/accounts-database.test.ts
@@ -891,6 +891,35 @@ describe("accounts-database", () => {
       expect(edits["same-cid"][0].content).toBe("edit2");
     });
 
+    test("deleteAccountEdit matches identical optimistic edits by clientId", async () => {
+      const acc = makeAccount({ id: "ge-client-id", name: "GEClientId" });
+      await accountsDatabase.addAccount(acc);
+      const baseEdit = {
+        commentCid: "same-cid",
+        communityAddress: "s",
+        deleted: true,
+        timestamp: 1,
+      };
+      await accountsDatabase.addAccountEdit(acc.id, {
+        ...baseEdit,
+        clientId: "existing-edit",
+      } as any);
+      await accountsDatabase.addAccountEdit(acc.id, {
+        ...baseEdit,
+        clientId: "failed-edit",
+      } as any);
+
+      const deleted = await accountsDatabase.deleteAccountEdit(acc.id, {
+        ...baseEdit,
+        clientId: "failed-edit",
+      } as any);
+
+      expect(deleted).toBe(true);
+      const edits = await accountsDatabase.getAccountEdits(acc.id);
+      expect(edits["same-cid"]).toHaveLength(1);
+      expect(edits["same-cid"][0].clientId).toBe("existing-edit");
+    });
+
     test("deleteAccountEdit is a no-op when the edit does not exist", async () => {
       const acc = makeAccount({ id: "ge-noop", name: "GENoop" });
       await accountsDatabase.addAccount(acc);

--- a/src/stores/accounts/accounts-database.ts
+++ b/src/stores/accounts/accounts-database.ts
@@ -543,6 +543,11 @@ const addAccountEdit = async (accountId: string, createEditOptions: CreateCommen
   ]);
 };
 
+const doesStoredAccountEditMatch = (storedAccountEdit: any, targetStoredAccountEdit: any) =>
+  storedAccountEdit?.clientId && targetStoredAccountEdit?.clientId
+    ? storedAccountEdit.clientId === targetStoredAccountEdit.clientId
+    : isEqual(storedAccountEdit, targetStoredAccountEdit);
+
 const deleteAccountEdit = async (accountId: string, editToDelete: CreateCommentOptions) => {
   assert(
     editToDelete?.commentCid && typeof editToDelete?.commentCid === "string",
@@ -554,7 +559,7 @@ const deleteAccountEdit = async (accountId: string, editToDelete: CreateCommentO
 
   let deletedEdit = false;
   const nextItems = items.filter((item) => {
-    if (!deletedEdit && isEqual(item, editToDelete)) {
+    if (!deletedEdit && doesStoredAccountEditMatch(item, editToDelete)) {
       deletedEdit = true;
       return false;
     }


### PR DESCRIPTION
## Summary
- normalize the stored optimistic `publishCommentEdit` payload before persisting it to state
- roll back the failed optimistic comment edit from Zustand and IndexedDB on terminal publish errors without removing older edits for the same comment
- add regression tests for rollback behavior in the accounts actions and accounts database layers

## Verification
- `yarn build` ✅
- `yarn prettier` ✅
- `yarn test src/stores/accounts/accounts-actions.test.ts src/stores/accounts/accounts-database.test.ts` ✅
- `yarn test` ✅
- `yarn test:coverage:hooks-stores` ❌ existing repo-wide 100% hooks/stores coverage gate is already below target across multiple files; current run also reports `src/stores/accounts/accounts-actions.ts` at 95.21% branch coverage

Closes #33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches optimistic edit persistence/rollback in both Zustand state and IndexedDB; bugs here could incorrectly drop or retain edits on publish errors. Changes are localized and covered by new regression tests but still affect user-visible edit history.
> 
> **Overview**
> Fixes optimistic `publishCommentEdit` persistence so failed terminal publishes are **rolled back** from both in-memory `accountsEdits` and the persisted edits DB, while preserving any older edits for the same comment.
> 
> Adds a per-edit `clientId` to disambiguate identical edits, introduces `accountsDatabase.deleteAccountEdit` to remove a single matching stored edit, and updates `useEditedComment` to ignore `clientId` when computing edited properties. Expands test coverage for rollback ordering, duplicate-error handling, preservation of older edits, and `deleteAccountEdit` semantics.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91e86ae08e8581ace9bb64f02e8b6929ea286af8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust rollback and persistence handling for comment edits to keep in-memory and stored edits consistent, including clientId-aware matching.
  * Preserve optimistic edits correctly after partial failures and ensure older identical edits remain when rollbacks occur.

* **Tests**
  * Expanded tests covering rollback, delete scenarios, clientId matching, and error/retry paths for publish/edit workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->