### PR TITLE
fix(accounts): rollback terminal comment edit challenge failures

### DIFF
--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -886,6 +886,58 @@ describe("accounts-actions", () => {
       expect(persistedEdits["cid"]).toBeUndefined();
     });
 
+    test("publishCommentEdit rolls back optimistic edit on terminal challengeverification failure", async () => {
+      const account = Object.values(accountsStore.getState().accounts)[0];
+      const accountId = accountsStore.getState().activeAccountId!;
+      const origCreate = account.plebbit.createCommentEdit.bind(account.plebbit);
+      const createCommentEditSpy = vi
+        .spyOn(account.plebbit, "createCommentEdit")
+        .mockImplementation(async (opts: any) => {
+          const publication = await origCreate(opts);
+          vi.spyOn(publication, "simulateChallengeVerificationEvent").mockImplementation(() => {
+            publication.emit("challengeverification", {
+              type: "CHALLENGEVERIFICATION",
+              challengeRequestId: publication.challengeRequestId,
+              challengeAnswerId: publication.challengeAnswerId,
+              challengeSuccess: false,
+              challengeErrors: {
+                lit: "CommentEditPubsubPublication is attempting to edit a comment while not being the original author of the comment",
+              },
+            });
+          });
+          return publication;
+        });
+
+      const onChallengeVerification = vi.fn();
+      await act(async () => {
+        await accountsActions.publishCommentEdit({
+          communityAddress: "sub.eth",
+          commentCid: "cid",
+          deleted: true,
+          onChallenge: (challenge: any, publication: any) =>
+            publication.publishChallengeAnswers(["4"]),
+          onChallengeVerification,
+        });
+      });
+
+      await new Promise((r) => setTimeout(r, 250));
+
+      expect(onChallengeVerification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          challengeSuccess: false,
+          challengeErrors: expect.objectContaining({
+            lit: expect.stringContaining("not being the original author"),
+          }),
+        }),
+        expect.anything(),
+      );
+      expect(createCommentEditSpy).toHaveBeenCalledTimes(1);
+      expect(accountsStore.getState().accountsEdits[accountId]?.["cid"]).toBeUndefined();
+
+      const persistedEdits = await accountsDatabase.getAccountEdits(accountId);
+      expect(persistedEdits["cid"]).toBeUndefined();
+    });
+
     test("publishCommentEdit rollback preserves older identical edits for the same comment", async () => {
       const account = Object.values(accountsStore.getState().accounts)[0];
       const nowSpy = vi.spyOn(Date, "now").mockReturnValue(1000);

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -135,6 +135,20 @@ const sanitizeStoredAccountEdit = (storedAccountEdit: any) => {
   return sanitizedStoredAccountEdit;
 };
 
+const hasTerminalChallengeVerificationError = (challengeVerification: any) => {
+  const challengeErrors = challengeVerification?.challengeErrors;
+  const hasChallengeErrors = Array.isArray(challengeErrors)
+    ? challengeErrors.length > 0
+    : challengeErrors && typeof challengeErrors === "object"
+      ? Object.keys(challengeErrors).length > 0
+      : Boolean(challengeErrors);
+
+  return (
+    !challengeVerification?.challengeSuccess &&
+    (hasChallengeErrors || Boolean(challengeVerification?.reason))
+  );
+};
+
 const addStoredAccountEditToState = (
   accountsEdits: Record<string, Record<string, any[]>>,
   accountId: string,
@@ -1128,6 +1142,11 @@ export const publishCommentEdit = async (
         publishCommentEditOptions.onChallengeVerification(challengeVerification, commentEdit);
         if (challengeVerification.challengeSuccess) {
           challengeSucceeded = true;
+        }
+        if (hasTerminalChallengeVerificationError(challengeVerification)) {
+          lastChallenge = undefined;
+          await rollbackStoredCommentEdit();
+          return;
         }
         if (!challengeVerification.challengeSuccess && lastChallenge) {
           // publish again automatically on fail


### PR DESCRIPTION
Follow-up to #33.\n\nThis handles the remaining terminal  failure path for , where the publication returns  with  or  instead of emitting an . In that case we now roll back the optimistic edit immediately instead of treating it as retryable.\n\nLocal verification:\n- yarn run v1.22.22
$ vitest src/stores/accounts/accounts-actions.test.ts src/stores/accounts/accounts-database.test.ts

 RUN  v4.1.0 /Users/Tommaso/Desktop/bitsocial/5chan

info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.\n- yarn run v1.22.22
$ yarn sync:directories && yarn generate:assets
$ node scripts/sync-directories.js
✅ Vendored directories already up to date
$ node scripts/generate-asset-manifest.js
✅ Generated asset manifest with 5 banners, 1 not-found images, 20 button images, and 2 background images
$ cross-env PUBLIC_URL=./ GENERATE_SOURCEMAP=false vite build
vite v8.0.0 building client environment for production...
[2Ktransforming...✓ 4348 modules transformed.
rendering chunks...
computing gzip size...
build/registerSW.js                                     0.13 kB
build/manifest.webmanifest                              0.48 kB
build/index.html                                        4.60 kB │ gzip:     1.46 kB
build/assets/account-data-editor-BWLzKd0U.css           0.67 kB │ gzip:     0.37 kB
build/assets/create-board-modal-Dxj1o63F.css            1.97 kB │ gzip:     0.76 kB
build/assets/boards-bar-edit-modal-DrJjxG8J.css         2.69 kB │ gzip:     0.98 kB
build/assets/challenge-modal-DvRRHTTP.css               2.95 kB │ gzip:     1.01 kB
build/assets/reply-modal-DM3BXloj.css                   2.95 kB │ gzip:     0.96 kB
build/assets/settings-modal-Ct-ivK3n.css                8.35 kB │ gzip:     2.04 kB
build/assets/index-CyGWocHk.css                       129.99 kB │ gzip:    18.90 kB
build/assets/use-directory-modal-store-BSyzMuqi.js      0.16 kB │ gzip:     0.13 kB
build/assets/directory-modal-DknVL9um.js                0.21 kB │ gzip:     0.17 kB
build/assets/disclaimer-modal-C0vCVchp.js               0.21 kB │ gzip:     0.17 kB
build/assets/native-CU7e9MP2.js                         0.31 kB │ gzip:     0.17 kB
build/assets/web-ClD6QJKI.js                            0.67 kB │ gzip:     0.33 kB
build/assets/esm-BbwRoNpT.js                            0.72 kB │ gzip:     0.45 kB
build/assets/rolldown-runtime-C5c2KzVm.js               1.26 kB │ gzip:     0.69 kB
build/assets/use-theme-q18MRD2X.js                      2.56 kB │ gzip:     1.26 kB
build/assets/ccip-Bht8Yz3i.js                           2.57 kB │ gzip:     1.23 kB
build/assets/create-board-modal-oYuqfjWS.js             2.94 kB │ gzip:     1.22 kB
build/assets/theme-monokai-FrfEN3nW.js                  3.10 kB │ gzip:     1.03 kB
build/assets/boards-bar-edit-modal-BjDkeSXo.js          3.19 kB │ gzip:     1.29 kB
build/assets/account-data-editor-CvH5W_QX.js            4.62 kB │ gzip:     1.94 kB
build/assets/mode-json-D8goIL0a.js                      5.35 kB │ gzip:     1.94 kB
build/assets/reply-modal-KFIK-cF_.js                    6.91 kB │ gzip:     2.74 kB
build/assets/dist-dNFZE8u6.js                           7.30 kB │ gzip:     2.95 kB
build/assets/challenge-modal-aFc1u7SU.js                7.49 kB │ gzip:     3.01 kB
build/assets/capitalize-DOmpIv92.js                    21.73 kB │ gzip:     6.35 kB
build/assets/settings-modal-yQXo454N.js                27.64 kB │ gzip:     7.56 kB
build/assets/floating-ui-ByfI3zjP.js                   52.22 kB │ gzip:    18.36 kB
build/assets/virtuoso-Dn1a3UKL.js                      58.23 kB │ gzip:    18.92 kB
build/assets/spring-gesture-kmA2J1wT.js                61.67 kB │ gzip:    23.23 kB
build/assets/vendor-C0gD0Lb6.js                       276.65 kB │ gzip:    86.97 kB
build/assets/index-Gx16Uikv.js                        354.11 kB │ gzip:    99.85 kB
build/assets/lib-C8D2QAEG.js                          516.84 kB │ gzip:   141.18 kB
build/assets/bitsocial-react-hooks-9yMdJhoo.js      5,666.16 kB │ gzip: 1,580.34 kB

✓ built in 889ms

PWA v1.2.0
Building src/sw.ts service worker ("es" format)...
vite v8.0.0 building client environment for production...
[2Ktransforming...✓ 66 modules transformed.
rendering chunks...
computing gzip size...
build/sw.mjs  15.93 kB │ gzip: 5.35 kB

✓ built in 14ms

PWA v1.2.0
mode      injectManifest
format:   es
precache  39 entries (7069.61 KiB)
files generated
  build/sw.js
Done in 4.16s.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `publishCommentEdit` retry/rollback flow when `challengeverification` fails with terminal error details, which can affect whether edits are persisted or retried. Risk is limited to comment-edit publishing but touches state+DB consistency paths.
> 
> **Overview**
> **Fixes terminal comment-edit failure handling.** `publishCommentEdit` now detects *non-retryable* `challengeverification` failures (unsuccessful with `challengeErrors`/`reason`) and immediately rolls back the optimistic edit from both store state and the accounts DB.
> 
> Adds a regression test asserting rollback occurs on this terminal `challengeverification` path (and that the edit is not re-published).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 358a70f175977227fd08062a97adf8a3eded3804. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->