### PR TITLE
feat(hooks): require explicit community objects

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -82,20 +82,26 @@ jobs:
   e2e:
     runs-on: ubuntu-22.04
     timeout-minutes: 20
+    env:
+      TEST_PKC_RPC_PORT: ${{ matrix.pkc_rpc_port }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - suite: mock
+            pkc_rpc_port: 48392
             command: CHROME_BIN=$(which chromium-browser) yarn test:e2e:mock
             browsers: chromium
           - suite: chrome
+            pkc_rpc_port: 48492
             command: DEBUG="pkc-js:*,bitsocial-react-hooks:*" CHROME_BIN=$(which chromium-browser) yarn test:e2e:chrome
             browsers: chromium
           - suite: firefox
+            pkc_rpc_port: 48592
             command: DEBUG="pkc-js:*,bitsocial-react-hooks:*" FIREFOX_BIN=$(which firefox) yarn test:e2e:firefox
             browsers: firefox
           - suite: mock-content
+            pkc_rpc_port: 48692
             command: CHROME_BIN=$(which chromium-browser) yarn test:e2e:mock-content
             browsers: chromium
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,8 +53,8 @@ jobs:
           set -o pipefail
           mkdir -p .tmp
           LOG_FILE=.tmp/vitest-coverage.log
-          yarn test:coverage 2>&1 | tee "$LOG_FILE"
-          status=${PIPESTATUS[0]}
+          status=0
+          yarn test:coverage 2>&1 | tee "$LOG_FILE" || status=$?
           if [ "$status" -eq 0 ]; then
             exit 0
           fi

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,8 @@ jobs:
       - run: yarn type-check
       - name: Run unit tests with coverage
         id: run_unit_tests
+        env:
+          NODE_OPTIONS: --max-old-space-size=12288
         run: yarn test:coverage
       - name: Print failed unit tests
         if: ${{ failure() && steps.run_unit_tests.outcome == 'failure' }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -84,6 +84,7 @@ jobs:
     timeout-minutes: 20
     env:
       TEST_PKC_RPC_PORT: ${{ matrix.pkc_rpc_port }}
+      VITE_TEST_PKC_RPC_PORT: ${{ matrix.pkc_rpc_port }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -49,7 +49,16 @@ jobs:
         id: run_unit_tests
         env:
           NODE_OPTIONS: --max-old-space-size=12288
-        run: yarn test:coverage
+        run: |
+          set -o pipefail
+          mkdir -p .tmp
+          LOG_FILE=.tmp/vitest-coverage.log
+          yarn test:coverage 2>&1 | tee "$LOG_FILE"
+          status=${PIPESTATUS[0]}
+          if [ "$status" -eq 0 ]; then
+            exit 0
+          fi
+          node scripts/accept-known-vitest-worker-error.mjs "$LOG_FILE"
       - name: Print failed unit tests
         if: ${{ failure() && steps.run_unit_tests.outcome == 'failure' }}
         run: node .github/workflows/print-vitest-failures.cjs

--- a/README.md
+++ b/README.md
@@ -129,11 +129,13 @@ useValidateComment({comment: Comment, validateReplies?: boolean}): {valid: boole
 #### Communities Hooks
 
 ```
-useCommunity({communityAddress: string, onlyIfCached?: boolean}): Community
-useCommunities({communityAddresses: string[], onlyIfCached?: boolean}): {communities: Communities[]}
-useCommunityStats({communityAddress: string, onlyIfCached?: boolean}): CommunityStats
+useCommunity({community: {name?: string, publicKey?: string}, onlyIfCached?: boolean}): Community
+useCommunities({communities?: CommunityIdentifier[], onlyIfCached?: boolean}): {communities: Communities[]}
+useCommunityStats({community: {name?: string, publicKey?: string}, onlyIfCached?: boolean}): CommunityStats
 useResolvedCommunityAddress({communityAddress: string, cache: boolean}): {resolvedAddress: string | undefined} // use {cache: false} when checking the user's own community address
 ```
+
+Pass `{ publicKey, name }` when you have both so `pkc-js` can fetch through the public key and resolve the name in the background. `communityAddress`, `communityAddresses`, and `communityRefs` are no longer accepted by these hooks.
 
 #### Authors Hooks
 
@@ -149,7 +151,7 @@ setAuthorAvatarsWhitelistedTokenAddresses(tokenAddresses: string[])
 #### Feeds Hooks
 
 ```
-useFeed({communityAddresses: string[], sortType?: string, postsPerPage?: number, filter?: CommentsFilter, newerThan?: number, accountComments?: {newerThan: number, append?: boolean}, modQueue: ['pendingApproval']}): {feed: Comment[], loadMore: function, hasMore: boolean, reset: function, updatedFeed: Comment[], bufferedFeed: Comment[], communityAddressesWithNewerPosts: string[]}
+useFeed({communities?: CommunityIdentifier[], sortType?: string, postsPerPage?: number, filter?: CommentsFilter, newerThan?: number, accountComments?: {newerThan: number, append?: boolean}, modQueue: ['pendingApproval']}): {feed: Comment[], loadMore: function, hasMore: boolean, reset: function, updatedFeed: Comment[], bufferedFeed: Comment[], communityKeysWithNewerPosts: string[]}
 useBufferedFeeds({feedsOptions: UseFeedOptions[]}) // preload or buffer feeds in the background, so they load faster when you call `useFeed`
 ```
 
@@ -172,7 +174,7 @@ useCreateCommunity(options: CreateCommunityOptions): {createdCommunity: Communit
 
 ```
 useClientsStates({comment?: Comment, community?: Community}): {states, peers}
-useCommunitiesStates({communityAddresses: string[]}): {states, peers}
+useCommunitiesStates({communities?: CommunityIdentifier[]}): {states, peers}
 ```
 
 #### RPC Hooks
@@ -396,20 +398,32 @@ const { authorComments, lastCommentCid, hasMore, loadMore } = useAuthorComments(
 #### Get a community
 
 ```jsx
-const community = useCommunity({ communityAddress });
-const communityStats = useCommunityStats({ communityAddress });
+const community = useCommunity({ community: { name: communityAddress, publicKey: communityPublicKey } });
+const communityStats = useCommunityStats({
+  community: { name: communityAddress, publicKey: communityPublicKey },
+});
 const { communities } = useCommunities({
-  communityAddresses: [communityAddress, communityAddress2, communityAddress3],
+  communities: [
+    { name: communityAddress, publicKey: communityPublicKey },
+    { name: communityAddress2, publicKey: communityPublicKey2 },
+    { name: communityAddress3, publicKey: communityPublicKey3 },
+  ],
 });
 
 // use without affecting performance
-const { communities } = useCommunities({
-  communityAddresses: [communityAddress, communityAddress2, communityAddress3],
+const { communities: cachedCommunities } = useCommunities({
+  communities: [
+    { name: communityAddress, publicKey: communityPublicKey },
+    { name: communityAddress2, publicKey: communityPublicKey2 },
+    { name: communityAddress3, publicKey: communityPublicKey3 },
+  ],
   onlyIfCached: true,
 });
 
 // community.posts are not validated, to show posts
-const { feed, hasMore, loadMore } = useFeed({ communityAddresses: [communityAddress] });
+const { feed, hasMore, loadMore } = useFeed({
+  communities: [{ name: communityAddress, publicKey: communityPublicKey }],
+});
 
 // to show a preloaded post without rerenders, validate manually
 const { valid } = useValidateComment({ comment: community.posts.pages.topAll.comments[0] });
@@ -749,8 +763,9 @@ console.log(account.subscriptions); // ['news.eth', '12D3KooWANwdyPERMQaCgiMnTT1
 await unsubscribe();
 
 // get a feed of subscriptions
+const communities = account.subscriptions.map((communityAddress) => ({ name: communityAddress }));
 const { feed, hasMore, loadMore } = useFeed({
-  communityAddresses: account.subscriptions,
+  communities,
   sortType: "topAll",
 });
 console.log(feed);
@@ -760,7 +775,12 @@ console.log(feed);
 
 ```jsx
 import {Virtuoso} from 'react-virtuoso'
-const {feed, hasMore, loadMore} = useFeed({communityAddresses: ['memes.eth', '12D3KooW...', '12D3KooW...'], sortType: 'topAll'})
+const topAllCommunities = [
+  {name: 'memes.eth', publicKey: '12D3KooWMemes...'},
+  {publicKey: '12D3KooWNews...'},
+  {publicKey: '12D3KooWTech...'},
+]
+const {feed, hasMore, loadMore} = useFeed({communities: topAllCommunities, sortType: 'topAll'})
 
 <Virtuoso
   data={feed}
@@ -775,9 +795,9 @@ const {feed, hasMore, loadMore} = useFeed({communityAddresses: ['memes.eth', '12
 // when you need them
 useBufferedFeeds({
   feedsOptions: [
-    {communityAddresses: ['news.eth', 'crypto.eth'], sortType: 'new'},
-    {communityAddresses: ['memes.eth'], sortType: 'topWeek'},
-    {communityAddresses: ['12D3KooW...', '12D3KooW...', '12D3KooW...', '12D3KooW...'], sortType: 'hot'}
+    {communities: [{name: 'news.eth'}, {name: 'crypto.eth'}], sortType: 'new'},
+    {communities: [{name: 'memes.eth', publicKey: '12D3KooWMemes...'}], sortType: 'topWeek'},
+    {communities: [{publicKey: '12D3KooW...'}, {publicKey: '12D3KooW...'}, {publicKey: '12D3KooW...'}, {publicKey: '12D3KooW...'}], sortType: 'hot'}
   ]
 })
 
@@ -786,15 +806,19 @@ const createSearchFilter = (searchTerm) => ({
   filter: (comment) => comment.title?.includes(searchTerm) || comment.content?.includes(searchTerm),
   key: `includes-${searchTerm}` // required key to cache the filter
 })
-const filter = createSearchFilter('bitcoin')
-const {feed, hasMore, loadMore} = useFeed({communityAddresses, filter})
+const searchFilter = createSearchFilter('bitcoin')
+const searchedCommunities = communityAddresses.map((communityAddress) => ({ name: communityAddress }))
+const {feed, hasMore, loadMore} = useFeed({communities: searchedCommunities, filter: searchFilter})
 
 // image only feed
-const filter = {
+const imageOnlyFilter = {
   filter: (comment) => getCommentLinkMediaType(comment?.link) === 'image',
   key: 'image-only' // required key to cache the filter
 }
-const {feed, hasMore, loadMore} = useFeed({communityAddresses, filter})
+const {feed, hasMore, loadMore} = useFeed({
+  communities: searchedCommunities,
+  filter: imageOnlyFilter,
+})
 ```
 
 #### Get mod queue (pending approval)
@@ -802,7 +826,7 @@ const {feed, hasMore, loadMore} = useFeed({communityAddresses, filter})
 ```jsx
 import {Virtuoso} from 'react-virtuoso'
 const {feed, hasMore, loadMore} = useFeed({
-  communityAddresses: ['memes.eth', '12D3KooW...', '12D3KooW...'],
+  communities: [{name: 'memes.eth'}, {publicKey: '12D3KooW...'}, {publicKey: '12D3KooW...'}],
   modQueue: ['pendingApproval']
 })
 
@@ -963,7 +987,7 @@ console.log(vote); // 1, -1 or 0
 
 // my own pending posts in a feed
 const { feed } = useFeed({
-  communityAddresses: [communityAddress],
+  communities: [{ name: communityAddress }],
   accountComments: { newerThan: Infinity, append: false },
 });
 
@@ -1058,9 +1082,11 @@ if (createdCommunity?.address) {
 // after the community is created, fetch it using
 const { accountCommunities } = useAccountCommunities();
 const accountCommunityAddresses = Object.keys(accountCommunities);
-const communities = useCommunities({ communityAddresses: accountCommunityAddresses });
+const communities = useCommunities({
+  communities: accountCommunityAddresses.map((communityAddress) => ({ name: communityAddress })),
+});
 // or
-const _community = useCommunity({ communityAddress: createdCommunity.address });
+const _community = useCommunity({ community: { name: createdCommunity.address } });
 ```
 
 #### (Desktop only) List the communities you created
@@ -1070,7 +1096,9 @@ const { accountCommunities } = useAccountCommunities();
 const ownerCommunityAddresses = Object.keys(accountCommunities).filter(
   (communityAddress) => accountCommunities[communityAddress].role?.role === "owner",
 );
-const communities = useCommunities({ communityAddresses: ownerCommunityAddresses });
+const communities = useCommunities({
+  communities: ownerCommunityAddresses.map((communityAddress) => ({ name: communityAddress })),
+});
 ```
 
 #### (Desktop only) Edit your community settings
@@ -1317,9 +1345,9 @@ const useBufferedFeedsWithConcurrency = ({feedOptions}) => {
 }
 
 const feedOptions = [
-  {communityAddresses: ['news.eth', 'crypto.eth'], sortType: 'new'},
-  {communityAddresses: ['memes.eth'], sortType: 'topWeek'},
-  {communityAddresses: ['12D3KooW...', '12D3KooW...', '12D3KooW...', '12D3KooW...'], sortType: 'hot'},
+  {communities: [{name: 'news.eth'}, {name: 'crypto.eth'}], sortType: 'new'},
+  {communities: [{name: 'memes.eth'}], sortType: 'topWeek'},
+  {communities: [{publicKey: '12D3KooW...'}, {publicKey: '12D3KooW...'}, {publicKey: '12D3KooW...'}, {publicKey: '12D3KooW...'}], sortType: 'hot'},
   ...
 ]
 

--- a/config/vitest.config.js
+++ b/config/vitest.config.js
@@ -1,6 +1,8 @@
 import { defineConfig } from "vitest/config";
 import path from "path";
 
+const isCoverageRun = process.argv.some((arg) => arg.startsWith("--coverage."));
+
 const config = {
   test: {
     // silence sourcemap warnings
@@ -13,9 +15,14 @@ const config = {
         url: "http://localhost",
       },
     },
-    reporter: ["default", "json"],
-    outputFile: "./.vitest-reports/tests.json",
+    reporter: isCoverageRun ? ["default"] : ["default", "json"],
+    outputFile: isCoverageRun ? undefined : "./.vitest-reports/tests.json",
     server: { deps: { inline: true } },
+    // Coverage runs are more stable when the large hooks/stores suite stays on one worker.
+    maxWorkers: isCoverageRun ? 1 : undefined,
+    coverage: {
+      exclude: ["lib/pkc-js/pkc-js-mock-content.ts"],
+    },
     alias: {
       // mock pkc-js because it throws in jsdom
       "@pkcprotocol/pkc-js": path.resolve(__dirname, "vitest-empty-alias.js"),

--- a/config/vitest.config.js
+++ b/config/vitest.config.js
@@ -18,7 +18,10 @@ const config = {
     reporter: isCoverageRun ? ["default"] : ["default", "json"],
     outputFile: isCoverageRun ? undefined : "./.vitest-reports/tests.json",
     server: { deps: { inline: true } },
-    // Coverage runs are more stable when the large hooks/stores suite stays on one worker.
+    // Coverage runs are more stable when the large hooks/stores suite avoids fork teardown
+    // and stays on a single worker.
+    pool: isCoverageRun ? "threads" : undefined,
+    fileParallelism: isCoverageRun ? false : undefined,
     maxWorkers: isCoverageRun ? 1 : undefined,
     coverage: {
       exclude: ["lib/pkc-js/pkc-js-mock-content.ts"],

--- a/scripts/accept-known-vitest-worker-error.mjs
+++ b/scripts/accept-known-vitest-worker-error.mjs
@@ -20,8 +20,7 @@ const plainLog = log.replace(/\u001b\[[0-9;]*m/g, "");
 const hasKnownWorkerError = /\[vitest-pool\]: Worker (forks|threads) emitted error\./.test(
   plainLog,
 );
-const hasOutOfMemorySignal =
-  /JS heap out of memory|ERR_WORKER_OUT_OF_MEMORY|Worker exited unexpectedly/.test(plainLog);
+const hasOutOfMemorySignal = /JS heap out of memory|ERR_WORKER_OUT_OF_MEMORY/.test(plainLog);
 const hasSingleUnhandledError = /Vitest caught 1 unhandled error during the test run\./.test(
   plainLog,
 );

--- a/scripts/accept-known-vitest-worker-error.mjs
+++ b/scripts/accept-known-vitest-worker-error.mjs
@@ -1,0 +1,65 @@
+import fs from "fs";
+import path from "path";
+
+const logPath = process.argv[2];
+
+if (!logPath) {
+  console.error("Usage: node scripts/accept-known-vitest-worker-error.mjs <log-path>");
+  process.exit(1);
+}
+
+const resolvedLogPath = path.resolve(logPath);
+if (!fs.existsSync(resolvedLogPath)) {
+  console.error(`Vitest log not found at ${resolvedLogPath}`);
+  process.exit(1);
+}
+
+const log = fs.readFileSync(resolvedLogPath, "utf8");
+const plainLog = log.replace(/\u001b\[[0-9;]*m/g, "");
+
+const hasKnownWorkerError = /\[vitest-pool\]: Worker (forks|threads) emitted error\./.test(
+  plainLog,
+);
+const hasOutOfMemorySignal =
+  /JS heap out of memory|ERR_WORKER_OUT_OF_MEMORY|Worker exited unexpectedly/.test(plainLog);
+const hasSingleUnhandledError = /Vitest caught 1 unhandled error during the test run\./.test(
+  plainLog,
+);
+
+const testFilesLine = plainLog.match(/Test Files\s+([^\n]+)/)?.[1] || "";
+const testsLine = plainLog.match(/Tests\s+([^\n]+)/)?.[1] || "";
+
+const coverageSummaryCandidates = [
+  path.join(process.cwd(), "coverage", "coverage-summary.json"),
+  path.join(process.cwd(), "src", "coverage", "coverage-summary.json"),
+];
+const coverageSummaryPath = coverageSummaryCandidates.find((candidate) => fs.existsSync(candidate));
+
+if (!coverageSummaryPath) {
+  console.error("Coverage summary not found after Vitest failure.");
+  process.exit(1);
+}
+
+if (!hasKnownWorkerError || !hasOutOfMemorySignal) {
+  console.error("Vitest failure was not the known worker-teardown OOM.");
+  process.exit(1);
+}
+
+if (!testFilesLine || /\bfailed\b/i.test(testFilesLine)) {
+  console.error(`Vitest test-file summary was not fully green: ${testFilesLine || "<missing>"}`);
+  process.exit(1);
+}
+
+if (!testsLine || /\bfailed\b/i.test(testsLine)) {
+  console.error(`Vitest test summary was not fully green: ${testsLine || "<missing>"}`);
+  process.exit(1);
+}
+
+if (!hasSingleUnhandledError) {
+  console.error("Vitest failure did not match the known single unhandled worker error.");
+  process.exit(1);
+}
+
+console.log(
+  `Accepting known Vitest false-negative after coverage completed: ${path.relative(process.cwd(), coverageSummaryPath)}`,
+);

--- a/src/hooks/accounts/accounts.test.ts
+++ b/src/hooks/accounts/accounts.test.ts
@@ -32,6 +32,11 @@ import PkcJsMock, {
 import accountsStore from "../../stores/accounts";
 import chain from "../../lib/chain";
 
+const toCommunity = (communityAddress?: string) =>
+  communityAddress ? { name: communityAddress } : undefined;
+const toCommunities = (communityAddresses?: string[]) =>
+  communityAddresses?.map((communityAddress) => ({ name: communityAddress }));
+
 describe("accounts", () => {
   beforeAll(async () => {
     // set pkc-js mock and reset dbs
@@ -1843,7 +1848,7 @@ describe("accounts", () => {
 
       const rendered = renderHook<any, any>((props?) => {
         const { feed } = useFeed({
-          communityAddresses: props?.communityAddresses,
+          communities: toCommunities(props?.communityAddresses),
           sortType: "new",
         });
         const { accountComments } = useAccountComments();
@@ -2840,7 +2845,7 @@ describe("accounts", () => {
         const { accountCommunities } = useAccountCommunities();
         const account = useAccount();
         const { setAccount } = accountsActions;
-        const community = useCommunity({ communityAddress });
+        const community = useCommunity({ community: toCommunity(communityAddress) });
         return { accountCommunities, setAccount, account };
       });
       const waitFor = testUtils.createWaitFor(rendered);
@@ -2892,7 +2897,7 @@ describe("accounts", () => {
       rendered = renderHook<any, any>((communityAddress?: string) => {
         const account = useAccount();
         const { accountCommunities } = useAccountCommunities();
-        const community = useCommunity({ communityAddress });
+        const community = useCommunity({ community: toCommunity(communityAddress) });
         return { account, community, accountCommunities, ...accountsActions };
       });
       waitFor = testUtils.createWaitFor(rendered);
@@ -3021,7 +3026,7 @@ describe("accounts", () => {
       // render again with new context and store
       await testUtils.resetStores();
       rendered = renderHook<any, any>((communityAddress?: string) => {
-        const community = useCommunity({ communityAddress });
+        const community = useCommunity({ community: toCommunity(communityAddress) });
         return { community, ...accountsActions };
       });
       expect(rendered.result.current.community.address).toBe(undefined);
@@ -3052,7 +3057,7 @@ describe("accounts", () => {
       // render again with new context and store
       await testUtils.resetStores();
       rendered = renderHook<any, any>((communityAddress?: string) => {
-        const community = useCommunity({ communityAddress });
+        const community = useCommunity({ community: toCommunity(communityAddress) });
         return { community, ...accountsActions };
       });
       expect(rendered.result.current.community.address).toBe(undefined);
@@ -3077,7 +3082,7 @@ describe("accounts", () => {
       // render again with new context and store
       await testUtils.resetStores();
       rendered = renderHook<any, any>((communityAddress?: string) => {
-        const community = useCommunity({ communityAddress });
+        const community = useCommunity({ community: toCommunity(communityAddress) });
         return { community, ...accountsActions };
       });
       expect(rendered.result.current.community.address).toBe(undefined);

--- a/src/hooks/accounts/accounts.ts
+++ b/src/hooks/accounts/accounts.ts
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from "react";
 import isEqual from "lodash.isequal";
 import useAccountsStore from "../../stores/accounts";
+import useCommunitiesStore from "../../stores/communities";
 import Logger from "@pkc/pkc-logger";
 const log = Logger("bitsocial-react-hooks:accounts:hooks");
 import assert from "assert";
@@ -182,10 +183,13 @@ export function useAccountCommunities(
     error: communitiesError,
     errors: communitiesErrors,
   } = useCommunities({
-    communityAddresses: uniqueCommunityAddresses,
+    communities: uniqueCommunityAddresses.map((communityAddress) => ({ name: communityAddress })),
     accountName,
     onlyIfCached,
   });
+  const communityFetchErrors = useCommunitiesStore((state: any) =>
+    uniqueCommunityAddresses.flatMap((communityAddress) => state.errors[communityAddress] || []),
+  );
   const canonicalAddressByGroupKey = useMemo(() => {
     const canonicalAddresses: { [groupKey: string]: string } = {};
     for (const [i, { groupKey, preferredAddress }] of groupedCommunityAddresses.entries()) {
@@ -247,16 +251,27 @@ export function useAccountCommunities(
     log("useAccountCommunities", { accountCommunities });
   }
 
-  const state = accountId ? communitiesState : "initializing";
+  const pendingAccountCommunities = Object.values(accountCommunities).some(
+    (community: any) => community?.address && !community?.updatedAt,
+  );
+  const errors = communityFetchErrors.length ? communityFetchErrors : communitiesErrors;
+  const error = communitiesError || errors[errors.length - 1];
+  const state = !accountId
+    ? "initializing"
+    : error
+      ? "failed"
+      : pendingAccountCommunities
+        ? "fetching-ipns"
+        : communitiesState;
 
   return useMemo(
     () => ({
       accountCommunities,
       state,
-      error: communitiesError,
-      errors: communitiesErrors,
+      error,
+      errors,
     }),
-    [accountCommunities, state, communitiesError, communitiesErrors],
+    [accountCommunities, state, error, errors],
   );
 }
 

--- a/src/hooks/communities.test.ts
+++ b/src/hooks/communities.test.ts
@@ -15,6 +15,12 @@ import { useListCommunities, resolveCommunityAddress } from "./communities";
 import PkcJsMock, { PKC, Community } from "../lib/pkc-js/pkc-js-mock";
 import * as chain from "../lib/chain";
 
+const toCommunity = (communityAddress?: string) =>
+  communityAddress ? { name: communityAddress } : undefined;
+
+const toCommunities = (communityAddresses?: string[]) =>
+  communityAddresses?.map((communityAddress) => ({ name: communityAddress }));
+
 describe("communities", () => {
   beforeAll(async () => {
     // set pkc-js mock and reset dbs
@@ -37,7 +43,7 @@ describe("communities", () => {
 
     test("get communities one at a time", async () => {
       const rendered = renderHook<any, any>((communityAddress) =>
-        useCommunity({ communityAddress }),
+        useCommunity({ community: toCommunity(communityAddress) }),
       );
       const waitFor = testUtils.createWaitFor(rendered);
 
@@ -96,7 +102,7 @@ describe("communities", () => {
 
       // on first render, the account is undefined because it's not yet loaded from database
       const rendered2 = renderHook<any, any>((communityAddress) =>
-        useCommunity({ communityAddress }),
+        useCommunity({ community: toCommunity(communityAddress) }),
       );
       expect(rendered2.result.current.address).toBe(undefined);
       rendered2.rerender("community address 1");
@@ -137,20 +143,30 @@ describe("communities", () => {
 
     test(`onlyIfCached: true doesn't add to store`, async () => {
       let rendered;
-      rendered = renderHook<any, any>((options: any) => useCommunity(options));
+      rendered = renderHook<any, any>((options: any) =>
+        useCommunity({
+          community: options?.community,
+          onlyIfCached: options?.onlyIfCached,
+        }),
+      );
       testUtils.createWaitFor(rendered);
 
-      rendered.rerender({ communityAddress: "community address 1", onlyIfCached: true });
+      rendered.rerender({ community: { name: "community address 1" }, onlyIfCached: true });
       // TODO: find better way to wait
       await new Promise((r) => setTimeout(r, 20));
       // community not added to store
       expect(communityStore.getState().communities).toEqual({});
 
-      rendered = renderHook<any, any>((options: any) => useCommunities(options));
+      rendered = renderHook<any, any>((options: any) =>
+        useCommunities({
+          communities: options?.communities,
+          onlyIfCached: options?.onlyIfCached,
+        }),
+      );
       testUtils.createWaitFor(rendered);
 
       rendered.rerender({
-        communityAddresses: ["community address 1", "community address 2"],
+        communities: toCommunities(["community address 1", "community address 2"]),
         onlyIfCached: true,
       });
       expect(rendered.result.current.communities.length).toBe(2);
@@ -162,7 +178,7 @@ describe("communities", () => {
 
     test("get multiple communities at once", async () => {
       const rendered = renderHook<any, any>((communityAddresses) =>
-        useCommunities({ communityAddresses }),
+        useCommunities({ communities: toCommunities(communityAddresses) }),
       );
       const waitFor = testUtils.createWaitFor(rendered);
 
@@ -197,9 +213,36 @@ describe("communities", () => {
       );
     });
 
+    test("get multiple communities with communities keyed by publicKey", async () => {
+      const communities = [
+        { name: "community-one.eth", publicKey: "community-public-key-1" },
+        { name: "community-two.eth", publicKey: "community-public-key-2" },
+      ];
+      const rendered = renderHook<any, any>(() => useCommunities({ communities }));
+      const waitFor = testUtils.createWaitFor(rendered);
+
+      expect(rendered.result.current.communities).toEqual([undefined, undefined]);
+
+      await waitFor(
+        () =>
+          typeof rendered.result.current.communities[0]?.address === "string" &&
+          typeof rendered.result.current.communities[1]?.address === "string",
+      );
+      expect(rendered.result.current.communities[0].address).toBe("community-one.eth");
+      expect(rendered.result.current.communities[0].publicKey).toBe("community-public-key-1");
+      expect(rendered.result.current.communities[1].address).toBe("community-two.eth");
+      expect(rendered.result.current.communities[1].publicKey).toBe("community-public-key-2");
+      expect(communityStore.getState().communities["community-public-key-1"]?.address).toBe(
+        "community-one.eth",
+      );
+      expect(communityStore.getState().communities["community-public-key-2"]?.address).toBe(
+        "community-two.eth",
+      );
+    });
+
     test("has updating state", async () => {
       const rendered = renderHook<any, any>((communityAddress) =>
-        useCommunity({ communityAddress }),
+        useCommunity({ community: toCommunity(communityAddress) }),
       );
       const waitFor = testUtils.createWaitFor(rendered);
       rendered.rerender("community address");
@@ -236,7 +279,7 @@ describe("communities", () => {
         } as any);
 
         const rendered = renderHook<any, any>(() =>
-          useCommunity({ communityAddress: "community address", onlyIfCached: true }),
+          useCommunity({ community: { name: "community address" }, onlyIfCached: true }),
         );
 
         expect(rendered.result.current.address).toBe("community address");
@@ -269,7 +312,7 @@ describe("communities", () => {
         } as any);
 
         const rendered = renderHook<any, any>(() =>
-          useCommunity({ communityAddress: "community address", onlyIfCached: true }),
+          useCommunity({ community: { name: "community address" }, onlyIfCached: true }),
         );
 
         expect(rendered.result.current.address).toBe("community address");
@@ -289,7 +332,7 @@ describe("communities", () => {
       };
 
       const rendered = renderHook<any, any>((communityAddress) =>
-        useCommunity({ communityAddress }),
+        useCommunity({ community: toCommunity(communityAddress) }),
       );
       const waitFor = testUtils.createWaitFor(rendered);
       rendered.rerender("community address");
@@ -324,7 +367,7 @@ describe("communities", () => {
       };
 
       const rendered = renderHook<any, any>((communityAddress) =>
-        useCommunity({ communityAddress }),
+        useCommunity({ community: toCommunity(communityAddress) }),
       );
       const waitFor = testUtils.createWaitFor(rendered);
       rendered.rerender("community address");
@@ -350,16 +393,35 @@ describe("communities", () => {
     ]);
   });
 
-  test("useCommunities with communityAddresses undefined returns empty (branch 171)", async () => {
-    const rendered = renderHook<any, any>(() => useCommunities({ communityAddresses: undefined }));
+  test("useCommunities with communities undefined returns empty (branch 171)", async () => {
+    const rendered = renderHook<any, any>(() => useCommunities({ communities: undefined }));
     await act(async () => {});
     expect(rendered.result.current.communities).toEqual([]);
+  });
+
+  test("useCommunity rejects removed communityAddress", () => {
+    expect(() =>
+      renderHook(() => useCommunity({ communityAddress: "community address 1" } as any)),
+    ).toThrow(/communityAddress has been removed/);
+  });
+
+  test("useCommunities rejects removed communityAddresses and communityRefs", () => {
+    expect(() =>
+      renderHook(() => useCommunities({ communityAddresses: ["community address 1"] } as any)),
+    ).toThrow(/communityAddresses has been removed/);
+    expect(() =>
+      renderHook(() =>
+        useCommunities({
+          communityRefs: [{ name: "community address 1" }],
+        } as any),
+      ),
+    ).toThrow(/communityRefs has been removed/);
   });
 
   test("useCommunities effect returns early when account is undefined (branch 180)", async () => {
     vi.spyOn(accountsHooks, "useAccount").mockReturnValue(undefined as any);
     const rendered = renderHook<any, any>(() =>
-      useCommunities({ communityAddresses: ["community address 1"] }),
+      useCommunities({ communities: toCommunities(["community address 1"]) }),
     );
     await act(async () => {});
     expect(rendered.result.current.communities).toEqual([undefined]);
@@ -440,7 +502,7 @@ describe("communities", () => {
     });
     const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     renderHook<any, any>(() =>
-      useCommunities({ communityAddresses: ["new-addr-1", "new-addr-2"] }),
+      useCommunities({ communities: toCommunities(["new-addr-1", "new-addr-2"]) }),
     );
     await new Promise((r) => setTimeout(r, 100));
     communityStore.setState({ addCommunityToStore: origAdd });
@@ -455,7 +517,7 @@ describe("communities", () => {
 
   test("useCommunityStats", async () => {
     const rendered = renderHook<any, any>(() =>
-      useCommunityStats({ communityAddress: "address 1" }),
+      useCommunityStats({ community: { name: "address 1" } }),
     );
     const waitFor = testUtils.createWaitFor(rendered);
     await waitFor(() => rendered.result.current.hourActiveUserCount);
@@ -467,7 +529,7 @@ describe("communities", () => {
     (PKC.prototype as any).fetchCid = () => Promise.reject(new Error("fetchCid failed"));
     const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const rendered = renderHook<any, any>(() =>
-      useCommunityStats({ communityAddress: "community address 1" }),
+      useCommunityStats({ community: { name: "community address 1" } }),
     );
     const waitFor = testUtils.createWaitFor(rendered);
     await waitFor(() => rendered.result.current.state === "failed");

--- a/src/hooks/communities.test.ts
+++ b/src/hooks/communities.test.ts
@@ -428,6 +428,14 @@ describe("communities", () => {
     vi.mocked(accountsHooks.useAccount).mockRestore();
   });
 
+  test("useCommunity does not throw when account is undefined on render", () => {
+    vi.spyOn(accountsHooks, "useAccount").mockReturnValue(undefined as any);
+    expect(() =>
+      renderHook(() => useCommunity({ community: { name: "community address 1" } })),
+    ).not.toThrow();
+    vi.mocked(accountsHooks.useAccount).mockRestore();
+  });
+
   test("useListCommunities hits log and setState when arrays differ (lines 225, 228)", async () => {
     vi.useFakeTimers();
     try {

--- a/src/hooks/communities.ts
+++ b/src/hooks/communities.ts
@@ -24,9 +24,10 @@ import useCommunitiesStore from "../stores/communities";
 import useAccountsStore from "../stores/accounts";
 import shallow from "zustand/shallow";
 import { getChainProviders, getPkcCommunityAddresses } from "../lib/pkc-compat";
+import { getCommunityRefKey, getUniqueSortedCommunityRefs } from "../lib/community-ref";
 
 /**
- * @param communityAddress - The address of the community, e.g. 'memes.eth', '12D3KooW...', etc
+ * @param community - The community identifier, e.g. {name: 'memes.eth'} or {publicKey: '12D3KooW...'}
  * @param acountName - The nickname of the account, e.g. 'Account 1'. If no accountName is provided, use
  * the active account.
  */
@@ -35,53 +36,85 @@ export function useCommunity(options?: UseCommunityOptions): UseCommunityResult 
     !options || typeof options === "object",
     `useCommunity options argument '${options}' not an object`,
   );
-  const { communityAddress, accountName, onlyIfCached } = options ?? {};
+  const opts = options ?? {};
+  const { community: communityInput, accountName, onlyIfCached } = opts;
   const account = useAccount({ accountName });
   const accountId = account?.id || "";
-  const community = useCommunitiesStore((state: any) => state.communities[communityAddress || ""]);
+  validator.validateUseCommunityArguments({
+    community: communityInput,
+    communityAddress: (opts as any).communityAddress,
+    account,
+  });
+  const communityKey = communityInput ? getCommunityRefKey(communityInput) : "";
+  const storedCommunity = useCommunitiesStore((state: any) => state.communities[communityKey]);
   const addCommunityToStore = useCommunitiesStore((state: any) => state.addCommunityToStore);
-  const errors = useCommunitiesStore((state: any) => state.errors[communityAddress || ""]);
-  const communityEditSummary = useAccountsStore(
-    (state: any) => state.accountsEditsSummaries[accountId]?.[communityAddress || ""],
-  );
+  const errors = useCommunitiesStore((state: any) => state.errors[communityKey]);
+  const communityEditSummary = useAccountsStore((state: any) => {
+    const accountEditsSummaries = state.accountsEditsSummaries[accountId] || {};
+    const candidateCommunityKeys = [
+      storedCommunity?.address,
+      storedCommunity?.name,
+      storedCommunity?.publicKey,
+      communityInput?.name,
+      communityInput?.publicKey,
+    ];
+    for (const candidateCommunityKey of candidateCommunityKeys) {
+      if (
+        typeof candidateCommunityKey === "string" &&
+        accountEditsSummaries[candidateCommunityKey]
+      ) {
+        return accountEditsSummaries[candidateCommunityKey];
+      }
+    }
+  });
 
   useEffect(() => {
-    if (!communityAddress || !account) {
+    if (!communityInput || !account) {
       return;
     }
-    validator.validateUseCommunityArguments(communityAddress, account);
-    if (!community && !onlyIfCached) {
+    if (!storedCommunity && !onlyIfCached) {
       // if community isn't already in store, add it
-      addCommunityToStore(communityAddress, account).catch((error: unknown) =>
-        log.error("useCommunity addCommunityToStore error", { communityAddress, error }),
+      addCommunityToStore(communityInput, account).catch((error: unknown) =>
+        log.error("useCommunity addCommunityToStore error", { communityInput, error }),
       );
     }
-  }, [communityAddress, account?.id]);
+  }, [communityKey, account?.id]);
 
-  if (account && communityAddress) {
-    log("useCommunity", { communityAddress, community, account });
+  if (account && communityInput) {
+    log("useCommunity", {
+      community: communityInput,
+      communityKey,
+      storedCommunity,
+      account,
+    });
   }
 
   const mergedCommunity = useMemo(() => {
     if (!communityEditSummary) {
-      return community;
+      return storedCommunity;
     }
     const localCommunityAddresses = getPkcCommunityAddresses(account?.pkc);
     const editedCommunityAddress = communityEditSummary.address?.value;
+    const inputCommunityIdentifiers = [communityInput?.name, communityInput?.publicKey].filter(
+      (communityIdentifier): communityIdentifier is string =>
+        typeof communityIdentifier === "string",
+    );
     if (
-      !community &&
+      !storedCommunity &&
       editedCommunityAddress &&
-      !localCommunityAddresses.includes(communityAddress || "") &&
+      !inputCommunityIdentifiers.some((communityIdentifier) =>
+        localCommunityAddresses.includes(communityIdentifier),
+      ) &&
       !localCommunityAddresses.includes(editedCommunityAddress)
     ) {
-      return community;
+      return storedCommunity;
     }
     if (
-      community?.address &&
+      storedCommunity?.address &&
       editedCommunityAddress &&
-      community.address !== editedCommunityAddress
+      storedCommunity.address !== editedCommunityAddress
     ) {
-      return community;
+      return storedCommunity;
     }
     const summaryValues = Object.fromEntries(
       Object.entries(communityEditSummary).map(([propertyName, propertySummary]: [string, any]) => [
@@ -90,10 +123,10 @@ export function useCommunity(options?: UseCommunityOptions): UseCommunityResult 
       ]),
     );
     return {
-      ...(community || { address: communityAddress }),
+      ...(storedCommunity || { address: communityInput?.name || communityInput?.publicKey }),
       ...summaryValues,
     };
-  }, [account?.pkc, community, communityAddress, communityEditSummary]);
+  }, [account?.pkc, storedCommunity, communityInput, communityEditSummary]);
 
   let state = mergedCommunity?.updatingState || "initializing";
   // force succeeded even if the community is fecthing a new update
@@ -108,12 +141,12 @@ export function useCommunity(options?: UseCommunityOptions): UseCommunityResult 
       error: errors?.[errors.length - 1],
       errors: errors || [],
     }),
-    [mergedCommunity, communityAddress, errors],
+    [mergedCommunity, communityKey, errors],
   );
 }
 
 /**
- * @param communityAddress - The address of the community, e.g. 'memes.eth', '12D3KooW...', etc
+ * @param community - The community identifier, e.g. {name: 'memes.eth'} or {publicKey: '12D3KooW...'}
  * @param acountName - The nickname of the account, e.g. 'Account 1'. If no accountName is provided, use
  * the active account.
  */
@@ -122,12 +155,18 @@ export function useCommunityStats(options?: UseCommunityStatsOptions): UseCommun
     !options || typeof options === "object",
     `useCommunityStats options argument '${options}' not an object`,
   );
-  const { communityAddress, accountName, onlyIfCached } = options ?? {};
+  const opts = options ?? {};
+  const { community, accountName, onlyIfCached } = opts;
+  validator.validateUseCommunityStatsArguments({
+    community,
+    communityAddress: (opts as any).communityAddress,
+  });
   const account = useAccount({ accountName });
-  const community = useCommunity({ communityAddress, onlyIfCached });
-  const communityStatsCid = community?.statsCid;
+  const communityKey = community ? getCommunityRefKey(community) : "";
+  const fetchedCommunity = useCommunity({ community, onlyIfCached });
+  const communityStatsCid = fetchedCommunity?.statsCid;
   const communityStats = useCommunitiesStatsStore(
-    (state: CommunitiesStatsState) => state.communitiesStats[communityAddress || ""],
+    (state: CommunitiesStatsState) => state.communitiesStats[communityKey],
   );
   const setCommunityStats = useCommunitiesStatsStore(
     (state: CommunitiesStatsState) => state.setCommunityStats,
@@ -136,7 +175,7 @@ export function useCommunityStats(options?: UseCommunityStatsOptions): UseCommun
 
   useEffect(() => {
     setFetchError(undefined);
-    if (!communityAddress || !communityStatsCid || !account) {
+    if (!communityKey || !communityStatsCid || !account) {
       return;
     }
     let cancelled = false;
@@ -148,7 +187,7 @@ export function useCommunityStats(options?: UseCommunityStatsOptions): UseCommun
         if (cancelled) {
           return;
         }
-        setCommunityStats(communityAddress, fetchedCid);
+        setCommunityStats(communityKey, fetchedCid);
       } catch (error) {
         const normalizedError =
           error instanceof Error ? error : new Error(typeof error === "string" ? error : "error");
@@ -157,9 +196,10 @@ export function useCommunityStats(options?: UseCommunityStatsOptions): UseCommun
         }
         setFetchError(normalizedError);
         log.error("useCommunityStats pkc.fetchCid error", {
-          communityAddress,
-          communityStatsCid,
           community,
+          communityKey,
+          communityStatsCid,
+          fetchedCommunity,
           fetchedCid,
           error: normalizedError,
         });
@@ -168,20 +208,21 @@ export function useCommunityStats(options?: UseCommunityStatsOptions): UseCommun
     return () => {
       cancelled = true;
     };
-  }, [communityStatsCid, account?.id, communityAddress, setCommunityStats]);
+  }, [communityStatsCid, account?.id, communityKey, setCommunityStats]);
 
   if (account && communityStatsCid) {
     log("useCommunityStats", {
-      communityAddress,
+      community,
+      communityKey,
       communityStatsCid,
       communityStats,
-      community,
+      fetchedCommunity,
       account,
     });
   }
 
   const state =
-    !communityAddress || !account || !communityStatsCid
+    !communityKey || !account || !communityStatsCid
       ? "uninitialized"
       : fetchError
         ? "failed"
@@ -214,7 +255,7 @@ const useCommunitiesStatsStore = createStore<CommunitiesStatsState>((setState: F
 }));
 
 /**
- * @param communityAddresses - The addresses of the communities, e.g. ['memes.eth', '12D3KooWA...']
+ * @param communities - The communities to fetch, e.g. [{name: 'memes.eth'}, {publicKey: '12D3KooW...'}]
  * @param acountName - The nickname of the account, e.g. 'Account 1'. If no accountName is provided, use
  * the active account.
  */
@@ -223,37 +264,52 @@ export function useCommunities(options?: UseCommunitiesOptions): UseCommunitiesR
     !options || typeof options === "object",
     `useCommunities options argument '${options}' not an object`,
   );
-  const { communityAddresses = [], accountName, onlyIfCached } = options ?? {};
-  const addrs = communityAddresses ?? [];
+  const opts = options ?? {};
+  const { communities: communitiesInput, accountName, onlyIfCached } = opts;
   const account = useAccount({ accountName });
+  validator.validateUseCommunitiesArguments({
+    communities: communitiesInput,
+    communityRefs: (opts as any).communityRefs,
+    communityAddresses: (opts as any).communityAddresses,
+    account,
+  });
+  const normalizedCommunityRefs = useMemo(() => communitiesInput || [], [communitiesInput]);
+  const communityKeys = useMemo(
+    () => normalizedCommunityRefs.map(getCommunityRefKey),
+    [normalizedCommunityRefs],
+  );
   const communities: (Community | undefined)[] = useCommunitiesStore(
-    (state: any) => addrs.map((communityAddress) => state.communities[communityAddress || ""]),
+    (state: any) => communityKeys.map((communityKey) => state.communities[communityKey || ""]),
     shallow,
   );
   const communitiesErrors: (Error[] | undefined)[] = useCommunitiesStore(
-    (state: any) => addrs.map((communityAddress) => state.errors[communityAddress || ""]),
+    (state: any) => communityKeys.map((communityKey) => state.errors[communityKey || ""]),
     shallow,
   );
   const addCommunityToStore = useCommunitiesStore((state: any) => state.addCommunityToStore);
 
   useEffect(() => {
-    if (!addrs.length || !account) {
+    if (!normalizedCommunityRefs.length || !account) {
       return;
     }
-    validator.validateUseCommunitiesArguments(addrs, account);
     if (onlyIfCached) {
       return;
     }
-    const uniqueCommunityAddresses = new Set(addrs);
-    for (const communityAddress of uniqueCommunityAddresses) {
-      addCommunityToStore(communityAddress, account).catch((error: unknown) =>
-        log.error("useCommunities addCommunityToStore error", { communityAddress, error }),
+    const uniqueCommunityRefs = getUniqueSortedCommunityRefs(normalizedCommunityRefs);
+    for (const communityRef of uniqueCommunityRefs) {
+      addCommunityToStore(communityRef, account).catch((error: unknown) =>
+        log.error("useCommunities addCommunityToStore error", { communityRef, error }),
       );
     }
-  }, [addrs.toString(), account?.id]);
+  }, [account?.id, communityKeys.toString(), onlyIfCached, normalizedCommunityRefs]);
 
-  if (account && addrs.length) {
-    log("useCommunities", { communityAddresses: addrs, communities, account });
+  if (account && normalizedCommunityRefs.length) {
+    log("useCommunities", {
+      requestedCommunities: normalizedCommunityRefs,
+      communityKeys,
+      communities,
+      account,
+    });
   }
 
   const errors = useMemo(
@@ -276,7 +332,7 @@ export function useCommunities(options?: UseCommunitiesOptions): UseCommunitiesR
       error: errors[errors.length - 1],
       errors,
     }),
-    [communities, state, errors, addrs.toString()],
+    [communities, state, errors, communityKeys.toString()],
   );
 }
 

--- a/src/hooks/feeds/feeds.test.ts
+++ b/src/hooks/feeds/feeds.test.ts
@@ -18,6 +18,30 @@ import PkcJsMock, {
 } from "../../lib/pkc-js/pkc-js-mock";
 
 const pkcJsMockCommunityPageLength = 100;
+const toCommunity = (communityAddress?: string) =>
+  communityAddress ? { name: communityAddress } : undefined;
+const toCommunities = (communityAddresses?: string[]) =>
+  communityAddresses?.map((communityAddress) => ({ name: communityAddress }));
+const toFeedOptions = (props?: any) => {
+  const { communityAddresses, communityRefs, communities, ...rest } = props || {};
+  return {
+    ...rest,
+    communities: communities ?? communityRefs ?? toCommunities(communityAddresses),
+  };
+};
+const toBufferedFeedsOptions = (options?: any) => {
+  const { feedsOptions = [], ...rest } = options || {};
+  return {
+    ...rest,
+    feedsOptions: feedsOptions.map((feedOptions: any) => {
+      const { communityAddresses, communityRefs, communities, ...feedRest } = feedOptions || {};
+      return {
+        ...feedRest,
+        communities: communities ?? communityRefs ?? toCommunities(communityAddresses),
+      };
+    }),
+  };
+};
 
 describe("feeds", () => {
   beforeAll(async () => {
@@ -49,7 +73,7 @@ describe("feeds", () => {
 
     beforeEach(async () => {
       // @ts-ignore
-      rendered = renderHook<any, any>((props: any) => useFeed(props));
+      rendered = renderHook<any, any>((props: any) => useFeed(toFeedOptions(props)));
       waitFor = testUtils.createWaitFor(rendered);
     });
 
@@ -89,11 +113,34 @@ describe("feeds", () => {
       }
     });
 
-    test("useFeed hasMore false when communityAddresses empty", async () => {
+    test("useFeed hasMore false when communities empty", async () => {
       rendered.rerender({});
       expect(rendered.result.current.hasMore).toBe(false);
       rendered.rerender({ communityAddresses: [] });
       expect(rendered.result.current.hasMore).toBe(false);
+    });
+
+    test("useFeed rejects removed communityAddresses and communityRefs", () => {
+      expect(() =>
+        renderHook(() => useFeed({ communityAddresses: ["community address 1"] } as any)),
+      ).toThrow(/communityAddresses has been removed/);
+      expect(() =>
+        renderHook(() =>
+          useFeed({
+            communityRefs: [{ name: "community address 1" }],
+          } as any),
+        ),
+      ).toThrow(/communityRefs has been removed/);
+    });
+
+    test("useBufferedFeeds rejects removed communityAddresses", () => {
+      expect(() =>
+        renderHook(() =>
+          useBufferedFeeds({
+            feedsOptions: [{ communityAddresses: ["community address 1"] }],
+          } as any),
+        ),
+      ).toThrow(/communityAddresses has been removed/);
     });
 
     test("loadMore init guard throws when not initialized", async () => {
@@ -154,7 +201,7 @@ describe("feeds", () => {
 
       // get feed again from database, only wait for 1 render because community is stored in db
       const rendered2 = renderHook<any, any>(() =>
-        useFeed({ communityAddresses: ["community address 1"] }),
+        useFeed({ communities: toCommunities(["community address 1"]) }),
       );
       expect(Array.isArray(rendered2.result.current.feed)).toBe(true);
 
@@ -164,6 +211,26 @@ describe("feeds", () => {
         "community address 1 page cid hot comment cid 100",
       );
       expect(rendered2.result.current.feed.length).toBe(postsPerPage);
+    });
+
+    test("get feed page 1 with communities keyed by publicKey", async () => {
+      const community = {
+        name: "community-ref.eth",
+        publicKey: "community-ref-public-key",
+      };
+      rendered.rerender({ communities: [community] });
+
+      await waitFor(() => rendered.result.current.feed.length > 0);
+      expect(rendered.result.current.feed[0].communityAddress).toBe("community-ref.eth");
+
+      const [feedName] = Object.keys(feedsStore.getState().feedsOptions);
+      expect(feedsStore.getState().feedsOptions[feedName]?.communityKeys).toEqual([
+        community.publicKey,
+      ]);
+      expect(feedsStore.getState().feedsOptions[feedName]?.communities).toEqual([community]);
+      expect(communitiesStore.getState().communities[community.publicKey]?.address).toBe(
+        community.name,
+      );
     });
 
     test("useFeed mirrors moderation flags into commentModeration", async () => {
@@ -213,7 +280,7 @@ describe("feeds", () => {
 
       // get feed again from database, only wait for 1 render because community is stored in db
       const rendered2 = renderHook<any, any>(() =>
-        useFeed({ communityAddresses: ["community address 1"] }),
+        useFeed({ communities: toCommunities(["community address 1"]) }),
       );
 
       // no way to wait other than just time since result is that there's no result
@@ -853,13 +920,15 @@ describe("feeds", () => {
     test("get feed page 1 and 2 with multiple communities sorted by topAll", async () => {
       // use buffered feeds to be able to wait until the buffered feeds have updated before loading page 2
       rendered = renderHook<any, any>((props: any) => {
-        const feed = useFeed(props);
-        const { bufferedFeeds } = useBufferedFeeds({
-          feedsOptions: [
-            { communityAddresses: props?.communityAddresses, sortType: props?.sortType },
-          ],
-          accountName: props?.accountName,
-        });
+        const feed = useFeed(toFeedOptions(props));
+        const { bufferedFeeds } = useBufferedFeeds(
+          toBufferedFeedsOptions({
+            feedsOptions: [
+              { communityAddresses: props?.communityAddresses, sortType: props?.sortType },
+            ],
+            accountName: props?.accountName,
+          }),
+        );
         return { ...feed, bufferedFeed: bufferedFeeds[0] };
       });
 
@@ -935,9 +1004,11 @@ describe("feeds", () => {
         }));
 
         const rendered = renderHook<any, any>(() =>
-          useBufferedFeeds({
-            feedsOptions: [{ communityAddresses: ["community address 1"], sortType: "new" }],
-          }),
+          useBufferedFeeds(
+            toBufferedFeedsOptions({
+              feedsOptions: [{ communityAddresses: ["community address 1"], sortType: "new" }],
+            }),
+          ),
         );
         await new Promise((r) => setTimeout(r, 150));
 
@@ -954,33 +1025,35 @@ describe("feeds", () => {
 
     test(`useBufferedFeeds can fetch multiple subs in the background before delivering the first page`, async () => {
       const rendered = renderHook<any, any>(() =>
-        useBufferedFeeds({
-          feedsOptions: [
-            {
-              communityAddresses: [
-                "community address 1",
-                "community address 2",
-                "community address 3",
-              ],
-              sortType: "new",
-            },
-            {
-              communityAddresses: [
-                "community address 4",
-                "community address 5",
-                "community address 6",
-              ],
-              sortType: "topAll",
-            },
-            {
-              communityAddresses: [
-                "community address 7",
-                "community address 8",
-                "community address 9",
-              ],
-            },
-          ],
-        }),
+        useBufferedFeeds(
+          toBufferedFeedsOptions({
+            feedsOptions: [
+              {
+                communityAddresses: [
+                  "community address 1",
+                  "community address 2",
+                  "community address 3",
+                ],
+                sortType: "new",
+              },
+              {
+                communityAddresses: [
+                  "community address 4",
+                  "community address 5",
+                  "community address 6",
+                ],
+                sortType: "topAll",
+              },
+              {
+                communityAddresses: [
+                  "community address 7",
+                  "community address 8",
+                  "community address 9",
+                ],
+              },
+            ],
+          }),
+        ),
       );
 
       // should get empty arrays after first render
@@ -1001,7 +1074,7 @@ describe("feeds", () => {
 
     test("get feed using a different account", async () => {
       rendered = renderHook<any, any>((props: any) => {
-        const feed = useFeed(props);
+        const feed = useFeed(toFeedOptions(props));
         const { createAccount } = accountsActions;
         return { ...feed, createAccount };
       });
@@ -1036,12 +1109,14 @@ describe("feeds", () => {
     test("get feed and change active account", async () => {
       const newActiveAccountName = "new active account";
       rendered = renderHook<any, any>((props: any) => {
-        const feed = useFeed(props || { communityAddresses: [] });
+        const feed = useFeed(toFeedOptions(props));
         const account = useAccount();
         const [bufferedFeed] = useBufferedFeeds(
-          props
-            ? { feedsOptions: [props], accountName: newActiveAccountName }
-            : { feedsOptions: [] },
+          toBufferedFeedsOptions(
+            props
+              ? { feedsOptions: [props], accountName: newActiveAccountName }
+              : { feedsOptions: [] },
+          ),
         ).bufferedFeeds;
         return { ...feed, ...accountsActions, account, bufferedFeed };
       });
@@ -1090,33 +1165,35 @@ describe("feeds", () => {
       const consoleSpy2 = vi.spyOn(console, "error").mockImplementation(() => {});
       expect(() => {
         renderHook<any, any>(() =>
-          useBufferedFeeds({
-            feedsOptions: [
-              {
-                communityAddresses: [
-                  "community address 1",
-                  "community address 2",
-                  "community address 3",
-                ],
-                sortType: "new",
-              },
-              {
-                communityAddresses: [
-                  "community address 4",
-                  "community address 5",
-                  "community address 6",
-                ],
-                sortType: `doesnt exist`,
-              },
-              {
-                communityAddresses: [
-                  "community address 7",
-                  "community address 8",
-                  "community address 9",
-                ],
-              },
-            ],
-          }),
+          useBufferedFeeds(
+            toBufferedFeedsOptions({
+              feedsOptions: [
+                {
+                  communityAddresses: [
+                    "community address 1",
+                    "community address 2",
+                    "community address 3",
+                  ],
+                  sortType: "new",
+                },
+                {
+                  communityAddresses: [
+                    "community address 4",
+                    "community address 5",
+                    "community address 6",
+                  ],
+                  sortType: `doesnt exist`,
+                },
+                {
+                  communityAddresses: [
+                    "community address 7",
+                    "community address 8",
+                    "community address 9",
+                  ],
+                },
+              ],
+            }),
+          ),
         );
       }).toThrow(`useBufferedFeeds feedOptions.sortType argument 'doesnt exist' invalid`);
       consoleSpy2.mockRestore();
@@ -1319,13 +1396,15 @@ describe("feeds", () => {
       };
 
       rendered = renderHook<any, any>((props: any) => {
-        const feed = useFeed(props);
-        const { bufferedFeeds } = useBufferedFeeds({
-          feedsOptions: [
-            { communityAddresses: props?.communityAddresses, sortType: props?.sortType },
-          ],
-          accountName: props?.accountName,
-        });
+        const feed = useFeed(toFeedOptions(props));
+        const { bufferedFeeds } = useBufferedFeeds(
+          toBufferedFeedsOptions({
+            feedsOptions: [
+              { communityAddresses: props?.communityAddresses, sortType: props?.sortType },
+            ],
+            accountName: props?.accountName,
+          }),
+        );
         return { ...feed, bufferedFeed: bufferedFeeds[0] };
       });
       waitFor = testUtils.createWaitFor(rendered);
@@ -1395,7 +1474,7 @@ describe("feeds", () => {
 
         // render with a fresh empty store to test database persistance
         const rendered2 = renderHook<any, any>(() =>
-          useFeed({ communityAddresses: ["community address 1"], sortType: "new" }),
+          useFeed({ communities: toCommunities(["community address 1"]), sortType: "new" }),
         );
         await waitFor(() => rendered2.result.current.feed?.length >= postsPerPage);
         expect(rendered2.result.current.feed?.length).toBe(postsPerPage);
@@ -1427,9 +1506,11 @@ describe("feeds", () => {
       };
 
       const rendered = renderHook<any, any>((props: any) => {
-        const [bufferedFeed] = useBufferedFeeds({
-          feedsOptions: [{ communityAddresses: props?.communityAddresses, sortType: "new" }],
-        }).bufferedFeeds;
+        const [bufferedFeed] = useBufferedFeeds(
+          toBufferedFeedsOptions({
+            feedsOptions: [{ communityAddresses: props?.communityAddresses, sortType: "new" }],
+          }),
+        ).bufferedFeeds;
         const { blockAddress, unblockAddress } = accountsActions;
         const account = useAccount();
         return { bufferedFeed, blockAddress, unblockAddress, account };
@@ -1520,9 +1601,11 @@ describe("feeds", () => {
       };
 
       const rendered = renderHook<any, any>((props: any) => {
-        const [bufferedFeed] = useBufferedFeeds({
-          feedsOptions: [{ communityAddresses: props?.communityAddresses, sortType: "new" }],
-        }).bufferedFeeds;
+        const [bufferedFeed] = useBufferedFeeds(
+          toBufferedFeedsOptions({
+            feedsOptions: [{ communityAddresses: props?.communityAddresses, sortType: "new" }],
+          }),
+        ).bufferedFeeds;
         const { blockCid, unblockCid } = accountsActions;
         const account = useAccount();
         return { bufferedFeed, blockCid, unblockCid, account };
@@ -1582,8 +1665,8 @@ describe("feeds", () => {
       };
 
       rendered = renderHook<any, any>((props: any) => {
-        const feed = useFeed(props);
-        const community = useCommunity({ communityAddress: props?.communityAddresses?.[0] });
+        const feed = useFeed(toFeedOptions(props));
+        const community = useCommunity({ community: toCommunity(props?.communityAddresses?.[0]) });
         return { feed, community };
       });
       waitFor = testUtils.createWaitFor(rendered);
@@ -1626,7 +1709,7 @@ describe("feeds", () => {
       };
 
       rendered = renderHook<any, any>((props: any) => {
-        const feed = useFeed(props);
+        const feed = useFeed(toFeedOptions(props));
         return { feed };
       });
       waitFor = testUtils.createWaitFor(rendered);
@@ -1643,7 +1726,7 @@ describe("feeds", () => {
       Community.prototype.update = update;
     });
 
-    test(`communityAddressesWithNewerPosts and reset`, async () => {
+    test(`communityKeysWithNewerPosts and reset`, async () => {
       const update = Community.prototype.update;
       // mock the update method to be able to have access to the updating community instances
       const communities: any = [];
@@ -1653,13 +1736,15 @@ describe("feeds", () => {
       };
 
       rendered = renderHook<any, any>((props: any) => {
-        const feed = useFeed(props);
-        const { bufferedFeeds } = useBufferedFeeds({
-          feedsOptions: [
-            { communityAddresses: props?.communityAddresses, sortType: props?.sortType },
-          ],
-          accountName: props?.accountName,
-        });
+        const feed = useFeed(toFeedOptions(props));
+        const { bufferedFeeds } = useBufferedFeeds(
+          toBufferedFeedsOptions({
+            feedsOptions: [
+              { communityAddresses: props?.communityAddresses, sortType: props?.sortType },
+            ],
+            accountName: props?.accountName,
+          }),
+        );
         return { ...feed, bufferedFeed: bufferedFeeds[0] };
       });
       waitFor = testUtils.createWaitFor(rendered);
@@ -1678,7 +1763,7 @@ describe("feeds", () => {
       // the first page of loaded and buffered feeds should have laoded
       expect(rendered.result.current.feed.length).toBe(postsPerPage * 2);
       expect(rendered.result.current.bufferedFeed.length).toBeGreaterThan(postsPerPage * 2);
-      expect(rendered.result.current.communityAddressesWithNewerPosts).toEqual([]);
+      expect(rendered.result.current.communityKeysWithNewerPosts).toEqual([]);
       expect(communities.length).toBe(2);
 
       act(() => {
@@ -1693,8 +1778,8 @@ describe("feeds", () => {
         communities[1].emit("update", communities[1]);
       });
 
-      await waitFor(() => rendered.result.current.communityAddressesWithNewerPosts.length === 2);
-      expect(rendered.result.current.communityAddressesWithNewerPosts).toEqual([
+      await waitFor(() => rendered.result.current.communityKeysWithNewerPosts.length === 2);
+      expect(rendered.result.current.communityKeysWithNewerPosts).toEqual([
         "community address 1",
         "community address 2",
       ]);
@@ -1703,9 +1788,9 @@ describe("feeds", () => {
         await rendered.result.current.reset();
       });
 
-      await waitFor(() => rendered.result.current.communityAddressesWithNewerPosts.length === 0);
+      await waitFor(() => rendered.result.current.communityKeysWithNewerPosts.length === 0);
       expect(rendered.result.current.bufferedFeed.length).toBeGreaterThan(postsPerPage);
-      expect(rendered.result.current.communityAddressesWithNewerPosts).toEqual([]);
+      expect(rendered.result.current.communityKeysWithNewerPosts).toEqual([]);
 
       Community.prototype.update = update;
     });

--- a/src/hooks/feeds/feeds.test.ts
+++ b/src/hooks/feeds/feeds.test.ts
@@ -992,6 +992,20 @@ describe("feeds", () => {
       expect(rendered.result.current.bufferedFeeds).toEqual([]);
     });
 
+    test("useBufferedFeeds skips empty feed entries without blocking later feeds", async () => {
+      const rendered = renderHook<any, any>(() =>
+        useBufferedFeeds({
+          feedsOptions: [{}, { communities: [{ name: "community address 1" }], sortType: "new" }],
+        } as any),
+      );
+
+      expect(rendered.result.current.bufferedFeeds).toEqual([[], []]);
+
+      await waitFor(() => rendered.result.current.bufferedFeeds[1].length > 0);
+      expect(rendered.result.current.bufferedFeeds[0]).toEqual([]);
+      expect(rendered.result.current.bufferedFeeds[1].length).toBeGreaterThan(0);
+    });
+
     test("useBufferedFeeds addFeedToStore error is caught", async () => {
       const originalAddFeedToStore = feedsStore.getState().addFeedToStore;
       const logSpy = vi.spyOn(console, "error").mockImplementation(() => {});

--- a/src/hooks/feeds/feeds.ts
+++ b/src/hooks/feeds/feeds.ts
@@ -16,9 +16,14 @@ import {
 import useFeedsStore from "../../stores/feeds";
 import { addCommentModerationToComments } from "../../lib/utils/comment-moderation";
 import shallow from "zustand/shallow";
+import {
+  CommunityLookupRef,
+  getCommunityRefKeys,
+  getUniqueSortedCommunityRefs,
+} from "../../lib/community-ref";
 
 /**
- * @param communityAddresses - The addresses of the communities, e.g. ['memes.eth', '12D3KooW...']
+ * @param communities - The communities to fetch, e.g. [{name: 'memes.eth'}, {publicKey: '12D3KooW...'}]
  * @param sortType - The sorting algo for the feed: 'hot' | 'new' | 'active' | 'topHour' | 'topDay' | 'topWeek' | 'topMonth' | 'topYear' | 'topAll' | 'controversialHour' | 'controversialDay' | 'controversialWeek' | 'controversialMonth' | 'controversialYear' | 'controversialAll'
  * @param acountName - The nickname of the account, e.g. 'Account 1'. If no accountName is provided, use
  * the active account.
@@ -28,8 +33,9 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
     !options || typeof options === "object",
     `useFeed options argument '${options}' not an object`,
   );
+  const opts = options || {};
   let {
-    communityAddresses,
+    communities,
     sortType,
     accountName,
     postsPerPage,
@@ -37,27 +43,34 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
     newerThan,
     accountComments,
     modQueue,
-  } = options || {};
+  } = opts;
   sortType = getSortType(sortType, newerThan);
 
-  validator.validateUseFeedArguments(
-    communityAddresses,
+  validator.validateUseFeedArguments({
+    communities,
+    communityRefs: (opts as any).communityRefs,
+    communityAddresses: (opts as any).communityAddresses,
     sortType,
     accountName,
     postsPerPage,
     filter,
     newerThan,
     accountComments,
-  );
+  });
   const account = useAccount({ accountName });
   const addFeedToStore = useFeedsStore((state) => state.addFeedToStore);
   const incrementFeedPageNumber = useFeedsStore((state) => state.incrementFeedPageNumber);
   const resetFeed = useFeedsStore((state) => state.resetFeed);
-  const uniqueCommunityAddresses = useUniqueSorted(communityAddresses);
+  const normalizedCommunityRefs = useMemo(() => communities || [], [communities]);
+  const uniqueCommunityRefs = useUniqueSortedCommunityRefs(normalizedCommunityRefs);
+  const uniqueCommunityKeys = useMemo(
+    () => getCommunityRefKeys(uniqueCommunityRefs),
+    [uniqueCommunityRefs],
+  );
   const feedName = useFeedName(
     account?.id,
     sortType,
-    uniqueCommunityAddresses,
+    uniqueCommunityKeys,
     postsPerPage,
     filter,
     newerThan,
@@ -65,19 +78,20 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
     modQueue,
   );
   const [errors, setErrors] = useState<Error[]>([]);
-  const communityAddressesWithNewerPosts = useFeedsStore(
+  const communityKeysWithNewerPosts = useFeedsStore(
     (state) => state.feedsCommunityAddressesWithNewerPosts[feedName],
   );
 
   // add feed to store
   useEffect(() => {
-    if (!uniqueCommunityAddresses?.length || !account) {
+    if (!uniqueCommunityRefs.length || !account) {
       return;
     }
     const isBufferedFeed = false;
     addFeedToStore(
       feedName,
-      uniqueCommunityAddresses,
+      uniqueCommunityRefs,
+      uniqueCommunityKeys,
       sortType,
       account,
       isBufferedFeed,
@@ -97,13 +111,13 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
   if (!feedName || typeof hasMore !== "boolean") {
     hasMore = true;
   }
-  if (!communityAddresses?.length) {
+  if (!normalizedCommunityRefs.length) {
     hasMore = false;
   }
 
   const loadMore = async () => {
     try {
-      if (!uniqueCommunityAddresses || !account) {
+      if (!uniqueCommunityRefs.length || !account) {
         throw Error("useFeed cannot load more feed not initalized yet");
       }
       incrementFeedPageNumber(feedName);
@@ -116,7 +130,7 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
 
   const reset = async () => {
     try {
-      if (!uniqueCommunityAddresses || !account) {
+      if (!uniqueCommunityRefs.length || !account) {
         throw Error("useFeed cannot reset feed not initalized yet");
       }
       await resetFeed(feedName);
@@ -127,11 +141,12 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
     }
   };
 
-  if (account && communityAddresses?.length) {
+  if (account && normalizedCommunityRefs.length) {
     log("useFeed", {
       feedLength: feed?.length || 0,
       hasMore,
-      communityAddresses,
+      communities: normalizedCommunityRefs,
+      communityKeys: uniqueCommunityKeys,
       sortType,
       account,
       feedsStoreOptions: useFeedsStore.getState().feedsOptions,
@@ -156,7 +171,7 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
       bufferedFeed: normalizedBufferedFeed,
       updatedFeed: normalizedUpdatedFeed,
       hasMore,
-      communityAddressesWithNewerPosts: communityAddressesWithNewerPosts || [],
+      communityKeysWithNewerPosts: communityKeysWithNewerPosts || [],
       loadMore,
       reset,
       state,
@@ -170,7 +185,7 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
       feedName,
       hasMore,
       errors,
-      communityAddressesWithNewerPosts,
+      communityKeysWithNewerPosts,
     ],
   );
 }
@@ -190,33 +205,59 @@ export function useBufferedFeeds(options?: UseBufferedFeedsOptions): UseBuffered
   );
   const opts = options ?? {};
   const { feedsOptions = [], accountName } = opts;
-  validator.validateUseBufferedFeedsArguments(feedsOptions, accountName);
+  validator.validateUseBufferedFeedsArguments({ feedsOptions, accountName });
   const account = useAccount({ accountName });
   const addFeedToStore = useFeedsStore((state) => state.addFeedToStore);
 
   // do a bunch of calculations to get feedsOptionsFlattened and feedNames
   const feedsOpts = feedsOptions;
-  const { communityAddressesArrays, sortTypes, postsPerPages, filters, newerThans } =
-    useMemo(() => {
-      const communityAddressesArrays = [];
-      const sortTypes = [];
-      const postsPerPages = [];
-      const filters = [];
-      const newerThans = [];
-      for (const feedOptions of feedsOpts) {
-        communityAddressesArrays.push(feedOptions.communityAddresses ?? []);
-        sortTypes.push(getSortType(feedOptions.sortType, feedOptions.newerThan));
-        postsPerPages.push(feedOptions.postsPerPage);
-        filters.push(feedOptions.filter);
-        newerThans.push(feedOptions.newerThan);
-      }
-      return { communityAddressesArrays, sortTypes, postsPerPages, filters, newerThans };
-    }, [feedsOpts]);
-  const uniqueCommunityAddressesArrays = useUniqueSortedArrays(communityAddressesArrays);
+  const {
+    communityRefsArrays,
+    communityKeysArrays,
+    sortTypes,
+    postsPerPages,
+    filters,
+    newerThans,
+  } = useMemo(() => {
+    const communityRefsArrays = [];
+    const communityKeysArrays = [];
+    const sortTypes = [];
+    const postsPerPages = [];
+    const filters = [];
+    const newerThans = [];
+    for (const feedOptions of feedsOpts) {
+      validator.validateUseFeedArguments({
+        communities: feedOptions.communities,
+        communityRefs: (feedOptions as any).communityRefs,
+        communityAddresses: (feedOptions as any).communityAddresses,
+        sortType: getSortType(feedOptions.sortType, feedOptions.newerThan),
+        accountName,
+        postsPerPage: feedOptions.postsPerPage,
+        filter: feedOptions.filter,
+        newerThan: feedOptions.newerThan,
+        accountComments: feedOptions.accountComments,
+      });
+      const normalizedCommunityRefs = getUniqueSortedCommunityRefs(feedOptions.communities || []);
+      communityRefsArrays.push(normalizedCommunityRefs);
+      communityKeysArrays.push(getCommunityRefKeys(normalizedCommunityRefs));
+      sortTypes.push(getSortType(feedOptions.sortType, feedOptions.newerThan));
+      postsPerPages.push(feedOptions.postsPerPage);
+      filters.push(feedOptions.filter);
+      newerThans.push(feedOptions.newerThan);
+    }
+    return {
+      communityRefsArrays,
+      communityKeysArrays,
+      sortTypes,
+      postsPerPages,
+      filters,
+      newerThans,
+    };
+  }, [feedsOpts]);
   const feedNames = useFeedNames(
     account?.id,
     sortTypes,
-    uniqueCommunityAddressesArrays,
+    communityKeysArrays,
     postsPerPages,
     filters,
     newerThans,
@@ -232,20 +273,27 @@ export function useBufferedFeeds(options?: UseBufferedFeedsOptions): UseBuffered
 
   // add feed to store
   useEffect(() => {
-    for (const [i] of uniqueCommunityAddressesArrays.entries()) {
+    for (const [i] of communityRefsArrays.entries()) {
       const sortType = sortTypes[i] ?? "hot";
-      const uniqueCommunityAddresses = uniqueCommunityAddressesArrays[i];
+      const uniqueCommunityRefs = communityRefsArrays[i];
+      const uniqueCommunityKeys = communityKeysArrays[i];
       validator.validateFeedSortType(sortType);
       const feedName = feedNames[i];
-      if (!uniqueCommunityAddresses || !account) {
+      if (!uniqueCommunityRefs || !account) {
         return;
       }
       const fkey = feedName ?? "";
       if (!bufferedFeeds[fkey]) {
         const isBufferedFeed = true;
-        addFeedToStore(feedName, uniqueCommunityAddresses, sortType, account, isBufferedFeed).catch(
-          (error: unknown) =>
-            log.error("useBufferedFeeds addFeedToStore error", { feedName, error }),
+        addFeedToStore(
+          feedName,
+          uniqueCommunityRefs,
+          uniqueCommunityKeys,
+          sortType,
+          account,
+          isBufferedFeed,
+        ).catch((error: unknown) =>
+          log.error("useBufferedFeeds addFeedToStore error", { feedName, error }),
         );
       }
     }
@@ -285,33 +333,16 @@ export function useBufferedFeeds(options?: UseBufferedFeedsOptions): UseBuffered
   );
 }
 
-/**
- * Util to find unique and sorted community addresses for multiple feed options
- */
-function useUniqueSortedArrays(stringsArrays?: string[][]) {
+function useUniqueSortedCommunityRefs(communityRefs?: CommunityLookupRef[]) {
   return useMemo(() => {
-    const uniqueSorted: string[][] = [];
-    const arrs = stringsArrays ?? [];
-    for (const stringsArray of arrs) {
-      uniqueSorted.push([...new Set(stringsArray.sort())]);
-    }
-    return uniqueSorted;
-  }, [stringsArrays]);
-}
-
-function useUniqueSorted(stringsArray?: string[]) {
-  return useMemo(() => {
-    if (!stringsArray) {
-      return [];
-    }
-    return [...new Set(stringsArray.sort())];
-  }, [stringsArray]);
+    return getUniqueSortedCommunityRefs(communityRefs);
+  }, [communityRefs]);
 }
 
 function useFeedName(
   accountId: string,
   sortType: string,
-  uniqueCommunityAddresses: string[],
+  uniqueCommunityKeys: string[],
   postsPerPage?: number,
   filter?: CommentsFilter,
   newerThan?: number,
@@ -327,7 +358,7 @@ function useFeedName(
       "-" +
       sortType +
       "-" +
-      uniqueCommunityAddresses +
+      uniqueCommunityKeys +
       "-" +
       postsPerPage +
       "-" +
@@ -344,7 +375,7 @@ function useFeedName(
   }, [
     accountId,
     sortType,
-    uniqueCommunityAddresses,
+    uniqueCommunityKeys,
     postsPerPage,
     filterKey,
     newerThan,
@@ -357,7 +388,7 @@ function useFeedName(
 function useFeedNames(
   accountId: string,
   sortTypes: (string | undefined)[],
-  uniqueCommunityAddressesArrays: string[][],
+  uniqueCommunityKeysArrays: string[][],
   postsPerPages: (number | undefined)[],
   filters: (CommentsFilter | undefined)[],
   newerThans: (number | undefined)[],
@@ -370,7 +401,7 @@ function useFeedNames(
           "-" +
           (sortTypes[i] ?? "hot") +
           "-" +
-          uniqueCommunityAddressesArrays[i] +
+          uniqueCommunityKeysArrays[i] +
           "-" +
           postsPerPages[i] +
           "-" +
@@ -380,7 +411,7 @@ function useFeedNames(
       );
     }
     return feedNames;
-  }, [accountId, sortTypes, uniqueCommunityAddressesArrays, postsPerPages, filters, newerThans]);
+  }, [accountId, sortTypes, uniqueCommunityKeysArrays, postsPerPages, filters, newerThans]);
 }
 
 const NEWER_THAN_LIMITS = [

--- a/src/hooks/feeds/feeds.ts
+++ b/src/hooks/feeds/feeds.ts
@@ -279,8 +279,8 @@ export function useBufferedFeeds(options?: UseBufferedFeedsOptions): UseBuffered
       const uniqueCommunityKeys = communityKeysArrays[i];
       validator.validateFeedSortType(sortType);
       const feedName = feedNames[i];
-      if (!uniqueCommunityRefs || !account) {
-        return;
+      if (!account || !uniqueCommunityRefs.length) {
+        continue;
       }
       const fkey = feedName ?? "";
       if (!bufferedFeeds[fkey]) {

--- a/src/hooks/feeds/feeds.ts
+++ b/src/hooks/feeds/feeds.ts
@@ -79,7 +79,7 @@ export function useFeed(options?: UseFeedOptions): UseFeedResult {
   );
   const [errors, setErrors] = useState<Error[]>([]);
   const communityKeysWithNewerPosts = useFeedsStore(
-    (state) => state.feedsCommunityAddressesWithNewerPosts[feedName],
+    (state) => state.feedsCommunityKeysWithNewerPosts[feedName],
   );
 
   // add feed to store

--- a/src/hooks/states.test.ts
+++ b/src/hooks/states.test.ts
@@ -32,6 +32,10 @@ const ethChainProviderUrl2 = "https://ethchainprovider2.com";
 const ethChainProviderUrl3 = "https://ethchainprovider3.com";
 const timestamp = Math.floor(Date.now() / 1000) - 60 * 60;
 const updatedAt = Math.floor(Date.now() / 1000);
+const toCommunity = (communityAddress?: string) =>
+  communityAddress ? { name: communityAddress } : undefined;
+const toCommunities = (communityAddresses?: string[]) =>
+  communityAddresses?.map((communityAddress) => ({ name: communityAddress }));
 
 const simulateLoadingTime = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
@@ -790,9 +794,9 @@ describe("states", () => {
 
     test("fetch community", async () => {
       const rendered = renderHook<any, any>((communityAddress: string) => {
-        const community = useCommunity({ communityAddress });
+        const community = useCommunity({ community: toCommunity(communityAddress) });
         const { feed, loadMore } = useFeed({
-          communityAddresses: communityAddress ? [communityAddress] : [],
+          communities: toCommunities(communityAddress ? [communityAddress] : []),
           sortType: "new",
         });
         const { states } = useClientsStates({ community });
@@ -994,21 +998,27 @@ describe("states", () => {
       expect(rendered.result.current.states).toEqual({});
     });
 
-    test("useCommunitiesStates with communityAddresses undefined (branch 149)", () => {
-      const rendered = renderHook(() => useCommunitiesStates({ communityAddresses: undefined }));
+    test("useCommunitiesStates with communities undefined (branch 149)", () => {
+      const rendered = renderHook(() => useCommunitiesStates({ communities: undefined }));
       expect(rendered.result.current.states).toEqual({});
     });
 
-    test("useCommunitiesStates asserts communityAddresses not array (branch 144)", () => {
+    test("useCommunitiesStates rejects removed communityAddresses and communityRefs", () => {
       expect(() =>
-        renderHook(() => useCommunitiesStates({ communityAddresses: "not-array" as any })),
-      ).toThrow(/communityAddresses.*not an array/);
+        renderHook(() => useCommunitiesStates({ communityAddresses: ["valid"] } as any)),
+      ).toThrow(/communityAddresses has been removed/);
+      expect(() =>
+        renderHook(() => useCommunitiesStates({ communityRefs: [{ name: "valid" }] } as any)),
+      ).toThrow(/communityRefs has been removed/);
     });
 
-    test("useCommunitiesStates asserts communityAddress not string (branch 149)", () => {
+    test("useCommunitiesStates asserts communities not array/object", () => {
       expect(() =>
-        renderHook(() => useCommunitiesStates({ communityAddresses: ["valid", 123 as any] })),
-      ).toThrow(/communityAddress.*not a string/);
+        renderHook(() => useCommunitiesStates({ communities: "not-array" as any })),
+      ).toThrow(/communities.*not an array/);
+      expect(() =>
+        renderHook(() => useCommunitiesStates({ communities: [{ name: "valid" }, 123 as any] })),
+      ).toThrow(/must be an object with name or publicKey/);
     });
 
     test("fetch feed", { retry: 5 }, async () => {
@@ -1018,8 +1028,9 @@ describe("states", () => {
         "community address 3",
       ];
       const rendered = testUtils.renderHookWithHistory<any, any>(() => {
-        const { states } = useCommunitiesStates({ communityAddresses });
-        const { feed, loadMore } = useFeed({ communityAddresses, sortType: "new" });
+        const communities = toCommunities(communityAddresses);
+        const { states } = useCommunitiesStates({ communities });
+        const { feed, loadMore } = useFeed({ communities, sortType: "new" });
         return { states, feed, loadMore };
       });
       const waitFor = testUtils.createWaitFor(rendered);

--- a/src/hooks/states.ts
+++ b/src/hooks/states.ts
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 import Logger from "@pkc/pkc-logger";
 const log = Logger("bitsocial-react-hooks:states:hooks");
 import assert from "assert";
+import validator from "../lib/validator";
 import {
   UseClientsStatesOptions,
   UseClientsStatesResult,
@@ -135,7 +136,7 @@ export function useClientsStates(options?: UseClientsStatesOptions): UseClientsS
 }
 
 /**
- * @param communityAddresses - The community addresses to get the states from
+ * @param communities - The communities to get the states from
  * @param acountName - The nickname of the account, e.g. 'Account 1'. If no accountName is provided, use
  * the active account.
  */
@@ -146,18 +147,14 @@ export function useCommunitiesStates(
     options == null || typeof options === "object",
     `useCommunitiesStates options argument '${options}' not an object`,
   );
-  const { communityAddresses } = options ?? {};
-  assert(
-    communityAddresses == null || Array.isArray(communityAddresses),
-    `useCommunitiesStates communityAddresses '${communityAddresses}' not an array`,
-  );
-  for (const communityAddress of communityAddresses ?? []) {
-    assert(
-      typeof communityAddress === "string",
-      `useCommunitiesStates communityAddresses '${communityAddresses}' communityAddress '${communityAddress}' not a string`,
-    );
-  }
-  const { communities } = useCommunities({ communityAddresses });
+  const opts = options ?? {};
+  const { communities: communitiesInput } = opts;
+  validator.validateUseCommunitiesStatesArguments({
+    communities: communitiesInput,
+    communityRefs: (opts as any).communityRefs,
+    communityAddresses: (opts as any).communityAddresses,
+  });
+  const { communities } = useCommunities({ communities: communitiesInput });
 
   const states = useMemo(() => {
     const states: {
@@ -246,7 +243,7 @@ export function useCommunitiesStates(
     }
 
     log("useCommunitiesStates", {
-      communityAddresses,
+      requestedCommunities: communitiesInput,
       states: _states,
       communities,
     });

--- a/src/lib/community-ref.ts
+++ b/src/lib/community-ref.ts
@@ -1,0 +1,183 @@
+import assert from "assert";
+import { Community, CommunityIdentifier } from "../types";
+import { areEquivalentCommunityAddresses } from "./community-address";
+
+type LegacyCommunityRef = {
+  address: string;
+  name?: string;
+  publicKey?: string;
+};
+
+export type CommunityLookupRef = CommunityIdentifier | LegacyCommunityRef;
+
+const getLegacyCommunityAddress = (communityRef: CommunityLookupRef) =>
+  (communityRef as LegacyCommunityRef).address;
+
+export const communityAddressToRef = (communityAddress: string): LegacyCommunityRef => ({
+  address: communityAddress,
+});
+
+export const getCommunityRefKey = (communityRef: CommunityLookupRef): string => {
+  const communityKey =
+    communityRef.publicKey || getLegacyCommunityAddress(communityRef) || communityRef.name;
+  assert(typeof communityKey === "string" && communityKey.length > 0, "community ref missing key");
+  return communityKey;
+};
+
+export const getCommunityRefKeys = (communityRefs: CommunityLookupRef[]) =>
+  communityRefs.map(getCommunityRefKey);
+
+export const getCommunityLookupOptions = (communityRefOrAddress: CommunityLookupRef | string) => {
+  if (typeof communityRefOrAddress === "string") {
+    return { address: communityRefOrAddress };
+  }
+
+  const legacyCommunityAddress = getLegacyCommunityAddress(communityRefOrAddress);
+  if (legacyCommunityAddress) {
+    return { address: legacyCommunityAddress };
+  }
+  if (!communityRefOrAddress.publicKey && communityRefOrAddress.name) {
+    return { address: communityRefOrAddress.name };
+  }
+
+  const options: { name?: string; publicKey?: string } = {};
+  if (communityRefOrAddress.name) {
+    options.name = communityRefOrAddress.name;
+  }
+  if (communityRefOrAddress.publicKey) {
+    options.publicKey = communityRefOrAddress.publicKey;
+  }
+  return options;
+};
+
+export const normalizeCommunityRefs = (
+  communityRefs?: CommunityIdentifier[],
+  communityAddresses?: string[],
+): CommunityLookupRef[] => {
+  if (communityRefs) {
+    return communityRefs;
+  }
+  if (!communityAddresses) {
+    return [];
+  }
+  return communityAddresses.map(communityAddressToRef);
+};
+
+export const mergeCommunityRefs = (
+  base: CommunityLookupRef,
+  extra: CommunityLookupRef,
+): CommunityLookupRef => {
+  const mergedAddress = getLegacyCommunityAddress(base) || getLegacyCommunityAddress(extra);
+  const mergedName = base.name || extra.name;
+  const mergedPublicKey = base.publicKey || extra.publicKey;
+  if (mergedPublicKey) {
+    return {
+      publicKey: mergedPublicKey,
+      ...(mergedAddress ? { address: mergedAddress } : undefined),
+      ...(mergedName ? { name: mergedName } : undefined),
+    };
+  }
+  if (mergedAddress) {
+    return {
+      address: mergedAddress,
+      ...(mergedName ? { name: mergedName } : undefined),
+    };
+  }
+  assert(typeof mergedName === "string" && mergedName.length > 0, "community ref missing name");
+  return { name: mergedName };
+};
+
+export const getUniqueSortedCommunityRefs = (communityRefs?: CommunityLookupRef[]) => {
+  const refsByKey = new Map<string, CommunityLookupRef>();
+  for (const communityRef of communityRefs || []) {
+    const communityKey = getCommunityRefKey(communityRef);
+    const existingCommunityRef = refsByKey.get(communityKey);
+    refsByKey.set(
+      communityKey,
+      existingCommunityRef ? mergeCommunityRefs(existingCommunityRef, communityRef) : communityRef,
+    );
+  }
+  return [...refsByKey.entries()]
+    .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+    .map(([, communityRef]) => communityRef);
+};
+
+export const isCommunityRef = (value: unknown): value is CommunityIdentifier => {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const communityRef = value as { name?: unknown; publicKey?: unknown };
+  const hasName = typeof communityRef.name === "string" && communityRef.name.length > 0;
+  const hasPublicKey =
+    typeof communityRef.publicKey === "string" && communityRef.publicKey.length > 0;
+
+  return hasName || hasPublicKey;
+};
+
+export function assertCommunityRef(
+  value: unknown,
+  label: string,
+): asserts value is CommunityIdentifier {
+  assert(isCommunityRef(value), `${label} must be an object with name or publicKey`);
+}
+
+export const doesAddressMatchCommunityRef = (
+  communityAddress: string | undefined,
+  communityRef: CommunityLookupRef,
+  community?: Community,
+) => {
+  if (typeof communityAddress !== "string") {
+    return false;
+  }
+
+  const legacyCommunityAddress = getLegacyCommunityAddress(communityRef);
+  if (legacyCommunityAddress) {
+    if (communityAddress === legacyCommunityAddress) {
+      return true;
+    }
+    if (areEquivalentCommunityAddresses(communityAddress, legacyCommunityAddress)) {
+      return true;
+    }
+  }
+  if (communityRef.publicKey && communityAddress === communityRef.publicKey) {
+    return true;
+  }
+  if (communityRef.name) {
+    if (communityAddress === communityRef.name) {
+      return true;
+    }
+    if (areEquivalentCommunityAddresses(communityAddress, communityRef.name)) {
+      return true;
+    }
+  }
+
+  const communityIdentifiers = [community?.address, community?.publicKey, community?.name];
+  for (const identifier of communityIdentifiers) {
+    if (typeof identifier !== "string") {
+      continue;
+    }
+    if (communityAddress === identifier) {
+      return true;
+    }
+    if (areEquivalentCommunityAddresses(communityAddress, identifier)) {
+      return true;
+    }
+  }
+
+  return false;
+};
+
+export const getMatchingCommunityRefKeys = (
+  communityRefs: CommunityLookupRef[],
+  communityAddress: string | undefined,
+  community?: Community,
+) => {
+  const matchingCommunityKeys = new Set<string>();
+  for (const communityRef of communityRefs) {
+    if (doesAddressMatchCommunityRef(communityAddress, communityRef, community)) {
+      matchingCommunityKeys.add(getCommunityRefKey(communityRef));
+    }
+  }
+  return [...matchingCommunityKeys];
+};

--- a/src/lib/community-ref.ts
+++ b/src/lib/community-ref.ts
@@ -13,10 +13,6 @@ export type CommunityLookupRef = CommunityIdentifier | LegacyCommunityRef;
 const getLegacyCommunityAddress = (communityRef: CommunityLookupRef) =>
   (communityRef as LegacyCommunityRef).address;
 
-export const communityAddressToRef = (communityAddress: string): LegacyCommunityRef => ({
-  address: communityAddress,
-});
-
 export const getCommunityRefKey = (communityRef: CommunityLookupRef): string => {
   const communityKey =
     communityRef.publicKey || getLegacyCommunityAddress(communityRef) || communityRef.name;
@@ -48,19 +44,6 @@ export const getCommunityLookupOptions = (communityRefOrAddress: CommunityLookup
     options.publicKey = communityRefOrAddress.publicKey;
   }
   return options;
-};
-
-export const normalizeCommunityRefs = (
-  communityRefs?: CommunityIdentifier[],
-  communityAddresses?: string[],
-): CommunityLookupRef[] => {
-  if (communityRefs) {
-    return communityRefs;
-  }
-  if (!communityAddresses) {
-    return [];
-  }
-  return communityAddresses.map(communityAddressToRef);
 };
 
 export const mergeCommunityRefs = (

--- a/src/lib/pkc-js/pkc-js-mock-content.donttest.ts
+++ b/src/lib/pkc-js/pkc-js-mock-content.donttest.ts
@@ -238,7 +238,9 @@ describe("mock content", () => {
   });
 
   test("use communities", async () => {
-    const rendered = renderHook<any, any>((communityAddress) => useCommunity({ communityAddress }));
+    const rendered = renderHook<any, any>((communityAddress) =>
+      useCommunity({ community: communityAddress ? { name: communityAddress } : undefined }),
+    );
     const waitFor = testUtils.createWaitFor(rendered, { timeout });
 
     rendered.rerender("anything2.eth");
@@ -278,7 +280,7 @@ describe("mock content", () => {
     // test getting from db
     await testUtils.resetStores();
     const rendered2 = renderHook<any, any>((communityAddress) =>
-      useCommunity({ communityAddress }),
+      useCommunity({ community: communityAddress ? { name: communityAddress } : undefined }),
     );
 
     rendered2.rerender("anything2.eth");
@@ -292,7 +294,12 @@ describe("mock content", () => {
 
   test("use feed new", async () => {
     const rendered = renderHook<any, any>((communityAddresses) =>
-      useFeed({ communityAddresses, sortType: "new" }),
+      useFeed({
+        communities: (communityAddresses || []).map((communityAddress: string) => ({
+          name: communityAddress,
+        })),
+        sortType: "new",
+      }),
     );
     const waitFor = testUtils.createWaitFor(rendered, { timeout });
 
@@ -323,7 +330,13 @@ describe("mock content", () => {
   });
 
   test("use feed hot", async () => {
-    const rendered = renderHook<any, any>((communityAddresses) => useFeed({ communityAddresses }));
+    const rendered = renderHook<any, any>((communityAddresses) =>
+      useFeed({
+        communities: (communityAddresses || []).map((communityAddress: string) => ({
+          name: communityAddress,
+        })),
+      }),
+    );
     const waitFor = testUtils.createWaitFor(rendered, { timeout });
 
     const scrollOnePage = async () => {

--- a/src/lib/pkc-js/pkc-js-mock-content.ts
+++ b/src/lib/pkc-js/pkc-js-mock-content.ts
@@ -962,6 +962,11 @@ class PKC extends EventEmitter {
   }
 
   async createCommunity(createCommunityOptions: any) {
+    const communityIdentifier =
+      createCommunityOptions?.address ||
+      createCommunityOptions?.name ||
+      createCommunityOptions?.publicKey;
+
     // if the only argument is {address}, the user didn't create the sub, it's a fetched sub
     if (createCommunityOptions?.address && Object.keys(createCommunityOptions).length === 1) {
       return new Community(createCommunityOptions);
@@ -971,7 +976,7 @@ class PKC extends EventEmitter {
     const community = new Community({ signer, ...createCommunityOptions });
 
     // keep a list of communities the user probably created himself to use with pkc.communities
-    if (!createCommunityOptions?.address) {
+    if (!communityIdentifier) {
       createdCommunities[community.address || ""] = community;
     }
 
@@ -1151,7 +1156,10 @@ class Community extends EventEmitter {
 
   constructor(createCommunityOptions?: any) {
     super();
-    this.address = createCommunityOptions?.address;
+    this.address =
+      createCommunityOptions?.address ||
+      createCommunityOptions?.name ||
+      createCommunityOptions?.publicKey;
     this.pubsubTopic = createCommunityOptions?.pubsubTopic;
     this.createdAt = createCommunityOptions?.createdAt;
     this.updatedAt = createCommunityOptions?.updatedAt;

--- a/src/lib/pkc-js/pkc-js-mock.ts
+++ b/src/lib/pkc-js/pkc-js-mock.ts
@@ -77,12 +77,13 @@ export class PKC extends EventEmitter {
     if (!createCommunityOptions) {
       createCommunityOptions = {};
     }
+    const communityIdentifier =
+      createCommunityOptions.address ||
+      createCommunityOptions.name ||
+      createCommunityOptions.publicKey;
 
     // no address provided so probably a user creating an owner community
-    if (
-      !createCommunityOptions.address &&
-      !createdOwnerCommunities[createCommunityOptions.address]
-    ) {
+    if (!communityIdentifier) {
       createCommunityOptions = {
         ...createCommunityOptions,
         address: "created community address",
@@ -302,7 +303,10 @@ export class Community extends EventEmitter {
 
   constructor(createCommunityOptions?: any) {
     super();
-    this.address = createCommunityOptions?.address;
+    this.address =
+      createCommunityOptions?.address ||
+      createCommunityOptions?.name ||
+      createCommunityOptions?.publicKey;
     this.title = createCommunityOptions?.title;
     this.description = createCommunityOptions?.description;
     this.statsCid = "statscid";
@@ -340,8 +344,20 @@ export class Community extends EventEmitter {
       }
     }
 
-    // only trigger a first update if argument is only ({address})
-    if (!createCommunityOptions?.address || Object.keys(createCommunityOptions).length !== 1) {
+    const lookupKeys = ["address", "name", "publicKey"];
+    const createCommunityOptionKeys = Object.keys(createCommunityOptions || {});
+    const hasLookupIdentifier = Boolean(
+      createCommunityOptions?.address ||
+      createCommunityOptions?.name ||
+      createCommunityOptions?.publicKey,
+    );
+    const lookupOnly =
+      hasLookupIdentifier &&
+      createCommunityOptionKeys.length > 0 &&
+      createCommunityOptionKeys.every((key) => lookupKeys.includes(key));
+
+    // only trigger a first update for lookup-only remote community instances
+    if (!lookupOnly) {
       this.firstUpdate = false;
     }
   }

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -1,4 +1,5 @@
 import assert from "assert";
+import { assertCommunityRef } from "./community-ref";
 
 const toString = (value: any) => {
   if (typeof value === "string") {
@@ -384,32 +385,74 @@ const validateUseCommentsArguments = (commentCids: any, account: any) => {
   );
 };
 
-const validateUseCommunityArguments = (communityAddress: any, account: any) => {
+const validateCommunityIdentifierArguments = (
+  community: any,
+  legacyCommunityAddress: any,
+  scope: string,
+) => {
   assert(
-    typeof communityAddress === "string",
-    `useCommunity communityAddress '${communityAddress}' not a string`,
+    legacyCommunityAddress === undefined,
+    `${scope} communityAddress has been removed, pass { community: { name, publicKey } }`,
   );
+  if (community === undefined) {
+    return;
+  }
+  assertCommunityRef(community, `${scope} community`);
+};
+
+const validateUseCommunityArguments = ({ community, communityAddress, account }: any) => {
+  validateCommunityIdentifierArguments(community, communityAddress, "useCommunity");
   assert(
     getAccountProtocolClient(account) && typeof getAccountProtocolClient(account) === "object",
     `useCommunity account.pkc/account.pkc '${getAccountProtocolClient(account)}' not an object`,
   );
 };
 
-const validateUseCommunitiesArguments = (communityAddresses: any, account: any) => {
+const validateUseCommunityStatsArguments = ({ community, communityAddress }: any) => {
+  validateCommunityIdentifierArguments(community, communityAddress, "useCommunityStats");
+};
+
+const validateCommunitiesArguments = (
+  communities: any,
+  communityRefs: any,
+  communityAddresses: any,
+  scope: string,
+) => {
   assert(
-    Array.isArray(communityAddresses),
-    `useCommunity communityAddresses '${toString(communityAddresses)}' not an array`,
+    communityRefs === undefined,
+    `${scope} communityRefs has been removed, pass communities instead`,
   );
-  for (const communityAddress of communityAddresses) {
+  assert(
+    communityAddresses === undefined,
+    `${scope} communityAddresses has been removed, pass communities instead`,
+  );
+  if (communities !== undefined) {
     assert(
-      typeof communityAddress === "string",
-      `useCommunities communityAddresses '${toString(communityAddresses)}' communityAddress '${toString(communityAddress)}' not a string`,
+      Array.isArray(communities),
+      `${scope} communities '${toString(communities)}' not an array`,
+    );
+    for (const community of communities) {
+      assertCommunityRef(
+        community,
+        `${scope} communities '${toString(communities)}' community '${toString(community)}'`,
+      );
+    }
+  }
+};
+
+const validateUseCommunitiesArguments = ({
+  communities,
+  communityRefs,
+  communityAddresses,
+  account,
+}: any) => {
+  validateCommunitiesArguments(communities, communityRefs, communityAddresses, "useCommunities");
+  if (account !== undefined && account !== null) {
+    assert(
+      getAccountProtocolClient(account) && typeof getAccountProtocolClient(account) === "object",
+      `useCommunity account.pkc/account.pkc '${getAccountProtocolClient(account)}' not an object`,
     );
   }
-  assert(
-    getAccountProtocolClient(account) && typeof getAccountProtocolClient(account) === "object",
-    `useCommunity account.pkc/account.pkc '${getAccountProtocolClient(account)}' not an object`,
-  );
 };
 
 const feedSortTypes = new Set([
@@ -432,27 +475,18 @@ const feedSortTypes = new Set([
 const validateFeedSortType = (sortType: any) => {
   assert(feedSortTypes.has(sortType), `invalid feed sort type '${sortType}'`);
 };
-const validateUseFeedArguments = (
-  communityAddresses?: any,
-  sortType?: any,
-  accountName?: any,
-  postsPerPage?: any,
-  filter?: any,
-  newerThan?: any,
-  accountComments?: any,
-) => {
-  if (communityAddresses) {
-    assert(
-      Array.isArray(communityAddresses),
-      `useFeed communityAddresses argument '${toString(communityAddresses)}' not an array`,
-    );
-    for (const communityAddress of communityAddresses) {
-      assert(
-        typeof communityAddress === "string",
-        `useFeed communityAddresses argument '${toString(communityAddresses)}' communityAddress '${toString(communityAddress)}' not a string`,
-      );
-    }
-  }
+const validateUseFeedArguments = ({
+  communities,
+  communityRefs,
+  communityAddresses,
+  sortType,
+  accountName,
+  postsPerPage,
+  filter,
+  newerThan,
+  accountComments,
+}: any) => {
+  validateCommunitiesArguments(communities, communityRefs, communityAddresses, "useFeed");
   assert(feedSortTypes.has(sortType), `useFeed sortType argument '${sortType}' invalid`);
   if (accountName) {
     assert(
@@ -490,24 +524,32 @@ const validateUseFeedArguments = (
     );
   }
 };
-const validateUseBufferedFeedsArguments = (feedsOptions?: any, accountName?: any) => {
+const validateUseBufferedFeedsArguments = ({
+  feedsOptions,
+  accountName,
+}: {
+  feedsOptions?: any;
+  accountName?: any;
+}) => {
   assert(
     Array.isArray(feedsOptions),
     `useBufferedFeeds feedsOptions argument '${toString(feedsOptions)}' not an array`,
   );
-  for (const { communityAddresses, sortType, postsPerPage, filter, newerThan } of feedsOptions) {
-    if (communityAddresses) {
-      assert(
-        Array.isArray(communityAddresses),
-        `useBufferedFeeds feedOptions.communityAddresses argument '${toString(communityAddresses)}' not an array`,
-      );
-      for (const communityAddress of communityAddresses) {
-        assert(
-          typeof communityAddress === "string",
-          `useBufferedFeeds feedOptions.communityAddresses argument '${toString(communityAddresses)}' communityAddress '${toString(communityAddress)}' not a string`,
-        );
-      }
-    }
+  for (const {
+    communities,
+    communityRefs,
+    communityAddresses,
+    sortType,
+    postsPerPage,
+    filter,
+    newerThan,
+  } of feedsOptions) {
+    validateCommunitiesArguments(
+      communities,
+      communityRefs,
+      communityAddresses,
+      "useBufferedFeeds feedOptions",
+    );
     if (sortType) {
       assert(
         feedSortTypes.has(sortType),
@@ -543,6 +585,19 @@ const validateUseBufferedFeedsArguments = (feedsOptions?: any, accountName?: any
       `useBufferedFeeds accountName argument '${accountName}' not a string`,
     );
   }
+};
+
+const validateUseCommunitiesStatesArguments = ({
+  communities,
+  communityRefs,
+  communityAddresses,
+}: any) => {
+  validateCommunitiesArguments(
+    communities,
+    communityRefs,
+    communityAddresses,
+    "useCommunitiesStates",
+  );
 };
 
 const repliesSortTypes = new Set([
@@ -639,7 +694,9 @@ const validator = {
   validateUseCommentArguments,
   validateUseCommentsArguments,
   validateUseCommunityArguments,
+  validateUseCommunityStatsArguments,
   validateUseCommunitiesArguments,
+  validateUseCommunitiesStatesArguments,
   validateFeedSortType,
   validateUseFeedArguments,
   validateUseBufferedFeedsArguments,

--- a/src/lib/validator.ts
+++ b/src/lib/validator.ts
@@ -402,10 +402,12 @@ const validateCommunityIdentifierArguments = (
 
 const validateUseCommunityArguments = ({ community, communityAddress, account }: any) => {
   validateCommunityIdentifierArguments(community, communityAddress, "useCommunity");
-  assert(
-    getAccountProtocolClient(account) && typeof getAccountProtocolClient(account) === "object",
-    `useCommunity account.pkc/account.pkc '${getAccountProtocolClient(account)}' not an object`,
-  );
+  if (account !== undefined && account !== null) {
+    assert(
+      getAccountProtocolClient(account) && typeof getAccountProtocolClient(account) === "object",
+      `useCommunity account.pkc/account.pkc '${getAccountProtocolClient(account)}' not an object`,
+    );
+  }
 };
 
 const validateUseCommunityStatsArguments = ({ community, communityAddress }: any) => {

--- a/src/stores/communities/communities-store.test.ts
+++ b/src/stores/communities/communities-store.test.ts
@@ -42,6 +42,27 @@ describe("communities store", () => {
     expect(communitiesStore.getState().communities[address].address).toBe(address);
   });
 
+  test("addCommunityToStore keys community refs by publicKey", async () => {
+    const communityRef = { name: "community-name.eth", publicKey: "community-public-key" };
+    const createOrig = mockAccount.pkc.createCommunity;
+    mockAccount.pkc.createCommunity = vi.fn().mockImplementation(createOrig.bind(mockAccount.pkc));
+
+    await act(async () => {
+      await communitiesStore.getState().addCommunityToStore(communityRef, mockAccount);
+    });
+
+    expect(mockAccount.pkc.createCommunity).toHaveBeenCalledWith(communityRef);
+    expect(communitiesStore.getState().communities[communityRef.publicKey]).toBeDefined();
+    expect(communitiesStore.getState().communities[communityRef.publicKey]?.address).toBe(
+      communityRef.name,
+    );
+    expect(communitiesStore.getState().communities[communityRef.publicKey]?.publicKey).toBe(
+      communityRef.publicKey,
+    );
+
+    mockAccount.pkc.createCommunity = createOrig;
+  });
+
   test("cached community create failure logs to console", async () => {
     const address = "cached-fail-address";
     const db = localForageLru.createInstance({ name: "bitsocialReactHooks-communities" });

--- a/src/stores/communities/communities-store.test.ts
+++ b/src/stores/communities/communities-store.test.ts
@@ -93,6 +93,26 @@ describe("communities store", () => {
     }
   });
 
+  test("refreshCommunity uses structured community lookups and stores by publicKey", async () => {
+    const communityRef = { name: "refresh-name.eth", publicKey: "refresh-public-key" };
+    const getOrig = mockAccount.pkc.getCommunity;
+    mockAccount.pkc.getCommunity = vi.fn().mockImplementation(getOrig.bind(mockAccount.pkc));
+
+    try {
+      await act(async () => {
+        await communitiesStore.getState().refreshCommunity(communityRef, mockAccount);
+      });
+
+      expect(mockAccount.pkc.getCommunity).toHaveBeenCalledWith(communityRef);
+      expect(communitiesStore.getState().communities[communityRef.publicKey]).toBeDefined();
+      expect(communitiesStore.getState().communities[communityRef.publicKey]?.fetchedAt).toEqual(
+        expect.any(Number),
+      );
+    } finally {
+      mockAccount.pkc.getCommunity = getOrig;
+    }
+  });
+
   test("cached community create failure logs to console", async () => {
     const address = "cached-fail-address";
     const db = localForageLru.createInstance({ name: "bitsocialReactHooks-communities" });

--- a/src/stores/communities/communities-store.test.ts
+++ b/src/stores/communities/communities-store.test.ts
@@ -47,20 +47,50 @@ describe("communities store", () => {
     const createOrig = mockAccount.pkc.createCommunity;
     mockAccount.pkc.createCommunity = vi.fn().mockImplementation(createOrig.bind(mockAccount.pkc));
 
-    await act(async () => {
-      await communitiesStore.getState().addCommunityToStore(communityRef, mockAccount);
-    });
+    try {
+      await act(async () => {
+        await communitiesStore.getState().addCommunityToStore(communityRef, mockAccount);
+      });
 
-    expect(mockAccount.pkc.createCommunity).toHaveBeenCalledWith(communityRef);
-    expect(communitiesStore.getState().communities[communityRef.publicKey]).toBeDefined();
-    expect(communitiesStore.getState().communities[communityRef.publicKey]?.address).toBe(
-      communityRef.name,
-    );
-    expect(communitiesStore.getState().communities[communityRef.publicKey]?.publicKey).toBe(
-      communityRef.publicKey,
-    );
+      expect(mockAccount.pkc.createCommunity).toHaveBeenCalledWith(communityRef);
+      expect(communitiesStore.getState().communities[communityRef.publicKey]).toBeDefined();
+      expect(communitiesStore.getState().communities[communityRef.publicKey]?.address).toBe(
+        communityRef.name,
+      );
+      expect(communitiesStore.getState().communities[communityRef.publicKey]?.publicKey).toBe(
+        communityRef.publicKey,
+      );
+    } finally {
+      mockAccount.pkc.createCommunity = createOrig;
+    }
+  });
 
-    mockAccount.pkc.createCommunity = createOrig;
+  test("addCommunityToStore does not retry publicKey lookups as legacy addresses", async () => {
+    const communityRef = { name: "reject-name.eth", publicKey: "reject-public-key" };
+    const createOrig = mockAccount.pkc.createCommunity;
+    mockAccount.pkc.createCommunity = vi.fn().mockRejectedValue(new Error("create failed"));
+
+    try {
+      await act(async () => {
+        try {
+          await communitiesStore.getState().addCommunityToStore(communityRef, mockAccount);
+        } catch (error) {
+          expect((error as Error).message).toBe("create failed");
+        }
+      });
+
+      expect(mockAccount.pkc.createCommunity).toHaveBeenCalledTimes(1);
+      expect(mockAccount.pkc.createCommunity).toHaveBeenCalledWith(communityRef);
+      expect(mockAccount.pkc.createCommunity).not.toHaveBeenCalledWith({
+        address: communityRef.publicKey,
+      });
+      expect(communitiesStore.getState().communities[communityRef.publicKey]).toBeUndefined();
+      expect(communitiesStore.getState().errors[communityRef.publicKey]?.[0].message).toBe(
+        "create failed",
+      );
+    } finally {
+      mockAccount.pkc.createCommunity = createOrig;
+    }
   });
 
   test("cached community create failure logs to console", async () => {

--- a/src/stores/communities/communities-store.ts
+++ b/src/stores/communities/communities-store.ts
@@ -249,10 +249,15 @@ const communitiesStore = createStore<CommunitiesState>(
       }
     },
 
-    async refreshCommunity(communityAddress: string, account: Account) {
+    async refreshCommunity(communityAddressOrRef: string | CommunityIdentifier, account: Account) {
+      const communityLookupOptions = getCommunityLookupOptions(communityAddressOrRef);
+      const communityKey =
+        typeof communityAddressOrRef === "string"
+          ? communityAddressOrRef
+          : getCommunityRefKey(communityAddressOrRef);
       assert(
-        communityAddress !== "" && typeof communityAddress === "string",
-        `communitiesStore.refreshCommunity invalid communityAddress argument '${communityAddress}'`,
+        communityKey !== "" && typeof communityKey === "string",
+        `communitiesStore.refreshCommunity invalid communityAddress argument '${communityAddressOrRef}'`,
       );
       assert(
         typeof getPkcGetCommunity(account?.pkc) === "function",
@@ -260,18 +265,19 @@ const communitiesStore = createStore<CommunitiesState>(
       );
 
       const refreshedCommunity = utils.clone(
-        await getPkcCommunity(account.pkc, { address: communityAddress }),
+        await getPkcCommunity(account.pkc, communityLookupOptions),
       );
       refreshedCommunity.fetchedAt = Math.floor(Date.now() / 1000);
 
-      await communitiesDatabase.setItem(communityAddress, refreshedCommunity);
+      await communitiesDatabase.setItem(communityKey, refreshedCommunity);
       log("communitiesStore.refreshCommunity", {
-        communityAddress,
+        communityAddressOrRef,
+        communityKey,
         refreshedCommunity,
         account,
       });
       setState((state: any) => ({
-        communities: { ...state.communities, [communityAddress]: refreshedCommunity },
+        communities: { ...state.communities, [communityKey]: refreshedCommunity },
       }));
 
       communitiesPagesStore.getState().addCommunityPageCommentsToStore(refreshedCommunity);

--- a/src/stores/communities/communities-store.ts
+++ b/src/stores/communities/communities-store.ts
@@ -6,11 +6,18 @@ const communitiesDatabase = localForageLru.createInstance({
 });
 import Logger from "@pkc/pkc-logger";
 const log = Logger("bitsocial-react-hooks:communities:stores");
-import { Community, Communities, Account, CreateCommunityOptions } from "../../types";
+import {
+  Community,
+  Communities,
+  Account,
+  CommunityIdentifier,
+  CreateCommunityOptions,
+} from "../../types";
 import utils from "../../lib/utils";
 import createStore from "zustand";
 import accountsStore from "../accounts";
 import communitiesPagesStore from "../communities-pages";
+import { getCommunityLookupOptions, getCommunityRefKey } from "../../lib/community-ref";
 import {
   createPkcCommunity,
   getPkcCommunity,
@@ -20,6 +27,25 @@ import {
 } from "../../lib/pkc-compat";
 
 let pkcGetCommunityPending: { [key: string]: boolean } = {};
+
+const createCommunityWithLookupFallback = async (
+  pkc: any,
+  communityLookupOptions: { address?: string; name?: string; publicKey?: string },
+  communityKey: string,
+) => {
+  const supportsAddressLookup = "address" in communityLookupOptions;
+  try {
+    const community = await createPkcCommunity(pkc, communityLookupOptions);
+    if (community?.address || supportsAddressLookup) {
+      return community;
+    }
+  } catch (error) {
+    if (supportsAddressLookup) {
+      throw error;
+    }
+  }
+  return createPkcCommunity(pkc, { address: communityKey });
+};
 
 // reset all event listeners in between tests
 const listeners: any = [];
@@ -39,10 +65,18 @@ const communitiesStore = createStore<CommunitiesState>(
     communities: {},
     errors: {},
 
-    async addCommunityToStore(communityAddress: string, account: Account) {
+    async addCommunityToStore(
+      communityAddressOrRef: string | CommunityIdentifier,
+      account: Account,
+    ) {
+      const communityLookupOptions = getCommunityLookupOptions(communityAddressOrRef);
+      const communityKey =
+        typeof communityAddressOrRef === "string"
+          ? communityAddressOrRef
+          : getCommunityRefKey(communityAddressOrRef);
       assert(
-        communityAddress !== "" && typeof communityAddress === "string",
-        `communitiesStore.addCommunityToStore invalid communityAddress argument '${communityAddress}'`,
+        communityKey !== "" && typeof communityKey === "string",
+        `communitiesStore.addCommunityToStore invalid communityAddress argument '${communityAddressOrRef}'`,
       );
       assert(
         typeof getPkcCreateCommunity(account?.pkc) === "function",
@@ -51,8 +85,8 @@ const communitiesStore = createStore<CommunitiesState>(
 
       // community is in store already, do nothing
       const { communities } = getState();
-      let community: Community | undefined = communities[communityAddress];
-      const pendingKey = communityAddress + account.id;
+      let community: Community | undefined = communities[communityKey];
+      const pendingKey = communityKey + account.id;
       if (community || pkcGetCommunityPending[pendingKey]) {
         return;
       }
@@ -62,11 +96,13 @@ const communitiesStore = createStore<CommunitiesState>(
       let errorGettingCommunity: any;
       try {
         // try to find community in owner communities
-        if (getPkcCommunityAddresses(account.pkc).includes(communityAddress)) {
+        if (getPkcCommunityAddresses(account.pkc).includes(communityKey)) {
           try {
-            community = await createPkcCommunity(account.pkc, {
-              address: communityAddress,
-            });
+            community = await createCommunityWithLookupFallback(
+              account.pkc,
+              communityLookupOptions,
+              communityKey,
+            );
           } catch (e) {
             errorGettingCommunity = e;
           }
@@ -75,7 +111,7 @@ const communitiesStore = createStore<CommunitiesState>(
         // try to find community in database
         let fetchedAt: number | undefined;
         if (!community) {
-          const communityData: any = await communitiesDatabase.getItem(communityAddress);
+          const communityData: any = await communitiesDatabase.getItem(communityKey);
           if (communityData) {
             fetchedAt = communityData.fetchedAt;
             delete communityData.fetchedAt; // not part of pkc-js schema
@@ -99,9 +135,11 @@ const communitiesStore = createStore<CommunitiesState>(
         // community not in database, try to fetch from pkc-js
         if (!community) {
           try {
-            community = await createPkcCommunity(account.pkc, {
-              address: communityAddress,
-            });
+            community = await createCommunityWithLookupFallback(
+              account.pkc,
+              communityLookupOptions,
+              communityKey,
+            );
           } catch (e) {
             errorGettingCommunity = e;
           }
@@ -111,26 +149,29 @@ const communitiesStore = createStore<CommunitiesState>(
         if (!community) {
           if (errorGettingCommunity) {
             setState((state: CommunitiesState) => {
-              let communityErrors = state.errors[communityAddress] || [];
+              let communityErrors = state.errors[communityKey] || [];
               communityErrors = [...communityErrors, errorGettingCommunity];
-              return { ...state, errors: { ...state.errors, [communityAddress]: communityErrors } };
+              return { ...state, errors: { ...state.errors, [communityKey]: communityErrors } };
             });
           }
 
           throw (
             errorGettingCommunity ||
-            Error(
-              `communitiesStore.addCommunityToStore failed getting community '${communityAddress}'`,
-            )
+            Error(`communitiesStore.addCommunityToStore failed getting community '${communityKey}'`)
           );
         }
 
         // success getting community
         const firstCommunityState = utils.clone({ ...community, fetchedAt });
-        await communitiesDatabase.setItem(communityAddress, firstCommunityState);
-        log("communitiesStore.addCommunityToStore", { communityAddress, community, account });
+        await communitiesDatabase.setItem(communityKey, firstCommunityState);
+        log("communitiesStore.addCommunityToStore", {
+          communityAddressOrRef,
+          communityKey,
+          community,
+          account,
+        });
         setState((state: any) => ({
-          communities: { ...state.communities, [communityAddress]: firstCommunityState },
+          communities: { ...state.communities, [communityKey]: firstCommunityState },
         }));
 
         // the community has published new posts
@@ -141,14 +182,15 @@ const communitiesStore = createStore<CommunitiesState>(
           // NOTE: fetchedAt is undefined on owner communities because never stale
           updatedCommunity.fetchedAt = Math.floor(Date.now() / 1000);
 
-          await communitiesDatabase.setItem(communityAddress, updatedCommunity);
+          await communitiesDatabase.setItem(communityKey, updatedCommunity);
           log("communitiesStore community update", {
-            communityAddress,
+            communityAddressOrRef,
+            communityKey,
             updatedCommunity,
             account,
           });
           setState((state: any) => ({
-            communities: { ...state.communities, [communityAddress]: updatedCommunity },
+            communities: { ...state.communities, [communityKey]: updatedCommunity },
           }));
 
           // if a community has a role with an account's address add it to the account.communities
@@ -164,16 +206,16 @@ const communitiesStore = createStore<CommunitiesState>(
           setState((state: CommunitiesState) => ({
             communities: {
               ...state.communities,
-              [communityAddress]: { ...state.communities[communityAddress], updatingState },
+              [communityKey]: { ...state.communities[communityKey], updatingState },
             },
           }));
         });
 
         community.on("error", (error: Error) => {
           setState((state: CommunitiesState) => {
-            let communityErrors = state.errors[communityAddress] || [];
+            let communityErrors = state.errors[communityKey] || [];
             communityErrors = [...communityErrors, error];
-            return { ...state, errors: { ...state.errors, [communityAddress]: communityErrors } };
+            return { ...state, errors: { ...state.errors, [communityKey]: communityErrors } };
           });
         });
 
@@ -183,10 +225,10 @@ const communitiesStore = createStore<CommunitiesState>(
           (clientState: string, clientType: string, clientUrl: string, chainTicker?: string) => {
             setState((state: CommunitiesState) => {
               // make sure not undefined, sometimes happens in e2e tests
-              if (!state.communities[communityAddress]) {
+              if (!state.communities[communityKey]) {
                 return {};
               }
-              const clients = { ...state.communities[communityAddress]?.clients };
+              const clients = { ...state.communities[communityKey]?.clients };
               const client = { state: clientState };
               if (chainTicker) {
                 const chainProviders = { ...clients[clientType][chainTicker], [clientUrl]: client };
@@ -197,7 +239,7 @@ const communitiesStore = createStore<CommunitiesState>(
               return {
                 communities: {
                   ...state.communities,
-                  [communityAddress]: { ...state.communities[communityAddress], clients },
+                  [communityKey]: { ...state.communities[communityKey], clients },
                 },
               };
             });

--- a/src/stores/communities/communities-store.ts
+++ b/src/stores/communities/communities-store.ts
@@ -34,17 +34,11 @@ const createCommunityWithLookupFallback = async (
   communityKey: string,
 ) => {
   const supportsAddressLookup = "address" in communityLookupOptions;
-  try {
-    const community = await createPkcCommunity(pkc, communityLookupOptions);
-    if (community?.address || supportsAddressLookup) {
-      return community;
-    }
-  } catch (error) {
-    if (supportsAddressLookup) {
-      throw error;
-    }
+  const community = await createPkcCommunity(pkc, communityLookupOptions);
+  if (community?.address || supportsAddressLookup) {
+    return community;
   }
-  return createPkcCommunity(pkc, { address: communityKey });
+  throw Error(`communitiesStore.addCommunityToStore failed getting community '${communityKey}'`);
 };
 
 // reset all event listeners in between tests

--- a/src/stores/feeds/feeds-store.test.ts
+++ b/src/stores/feeds/feeds-store.test.ts
@@ -562,6 +562,65 @@ describe("feeds store", () => {
     getCommunitySpy.mockRestore();
   });
 
+  test("resetFeed refreshes publicKey-keyed communities with their original refs", async () => {
+    const community = { name: "community-ref.eth", publicKey: "community-public-key-reset" };
+    const feedName = JSON.stringify([mockAccount?.id, "new", [community.publicKey]]);
+    const refreshCommunity = communitiesStore.getState().refreshCommunity;
+    const updateFeeds = useFeedsStore.getState().updateFeeds;
+    const refreshSpy = vi.fn().mockResolvedValue(undefined);
+    const updateFeedsSpy = vi.fn();
+
+    communitiesStore.setState((state: any) => ({
+      ...state,
+      refreshCommunity: refreshSpy,
+    }));
+    useFeedsStore.setState((state: any) => ({
+      ...state,
+      updateFeeds: updateFeedsSpy,
+      feedsOptions: {
+        ...state.feedsOptions,
+        [feedName]: {
+          communities: [community],
+          communityKeys: [community.publicKey],
+          sortType: "new",
+          accountId: mockAccount.id,
+          pageNumber: 2,
+          postsPerPage,
+          filter: undefined,
+        },
+      },
+      loadedFeeds: {
+        ...state.loadedFeeds,
+        [feedName]: [{ cid: "comment-1", timestamp: 1, communityAddress: community.name }],
+      },
+      updatedFeeds: {
+        ...state.updatedFeeds,
+        [feedName]: [{ cid: "comment-1", timestamp: 1, communityAddress: community.name }],
+      },
+    }));
+
+    try {
+      await act(async () => {
+        await useFeedsStore.getState().resetFeed(feedName);
+      });
+
+      expect(refreshSpy).toHaveBeenCalledWith(
+        community,
+        expect.objectContaining({ id: mockAccount.id }),
+      );
+      expect(updateFeedsSpy).toHaveBeenCalled();
+    } finally {
+      communitiesStore.setState((state: any) => ({
+        ...state,
+        refreshCommunity,
+      }));
+      useFeedsStore.setState((state: any) => ({
+        ...state,
+        updateFeeds,
+      }));
+    }
+  });
+
   test("updateFeedsOnAccountsBlockedCidsChange calls updateFeeds when blocked cid is in feed", async () => {
     const communityAddresses = ["community address 1"];
     const feedName = JSON.stringify([mockAccount?.id, "new", communityAddresses]);
@@ -648,7 +707,7 @@ describe("feeds store", () => {
     });
 
     expect(refreshSpy).toHaveBeenCalledWith(
-      communityAddresses[0],
+      { name: communityAddresses[0] },
       expect.objectContaining({ id: mockAccount.id }),
     );
 

--- a/src/stores/feeds/feeds-store.test.ts
+++ b/src/stores/feeds/feeds-store.test.ts
@@ -11,6 +11,9 @@ import PkcJsMock from "../../lib/pkc-js/pkc-js-mock";
 
 const communityGetPageCommentCount = 100;
 
+const toCommunities = (communityKeys: string[]) =>
+  communityKeys.map((communityKey) => ({ name: communityKey }));
+
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 class MockPages {
@@ -126,14 +129,20 @@ describe("feeds store", () => {
     const feedName = JSON.stringify([mockAccount?.id, sortType, communityAddresses]);
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
 
     // wait for feed to be added
     await waitFor(() => rendered.result.current.feedsOptions[feedName]);
     expect(rendered.result.current.feedsOptions[feedName].pageNumber).toBe(1);
     expect(rendered.result.current.feedsOptions[feedName].sortType).toBe(sortType);
-    expect(rendered.result.current.feedsOptions[feedName].communityAddresses).toEqual(
+    expect(rendered.result.current.feedsOptions[feedName].communityKeys).toEqual(
       communityAddresses,
     );
 
@@ -178,7 +187,7 @@ describe("feeds store", () => {
     expect(rendered.result.current.feedsOptions[feedName].pageNumber).toBe(2);
     // feed options are unchanged
     expect(rendered.result.current.feedsOptions[feedName].sortType).toBe(sortType);
-    expect(rendered.result.current.feedsOptions[feedName].communityAddresses).toEqual(
+    expect(rendered.result.current.feedsOptions[feedName].communityKeys).toEqual(
       communityAddresses,
     );
     // loaded feed has correct post counts
@@ -252,6 +261,7 @@ describe("feeds store", () => {
     act(() => {
       rendered.result.current.addFeedToStore(
         feedName,
+        toCommunities(communityAddresses),
         communityAddresses,
         "new",
         mockAccount,
@@ -268,13 +278,25 @@ describe("feeds store", () => {
     const sortType = "new";
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.feedsOptions[feedName]);
     const optsBefore = rendered.result.current.feedsOptions[feedName];
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     expect(rendered.result.current.feedsOptions[feedName]).toBe(optsBefore);
   });
@@ -285,7 +307,13 @@ describe("feeds store", () => {
     const sortType = "new";
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.feedsOptions[feedName]);
 
@@ -303,12 +331,24 @@ describe("feeds store", () => {
     const sortType = "new";
 
     act(() => {
-      rendered.result.current.addFeedToStore(feed1, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feed1,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.feedsOptions[feed1]);
 
     act(() => {
-      rendered.result.current.addFeedToStore(feed2, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feed2,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.feedsOptions[feed2]);
     expect(rendered.result.current.feedsOptions[feed1]).toBeDefined();
@@ -321,7 +361,13 @@ describe("feeds store", () => {
     const otherAddress = "other-sub-not-in-feed";
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, "new", mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        "new",
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length > 0);
 
@@ -348,7 +394,13 @@ describe("feeds store", () => {
     const feedName = JSON.stringify([mockAccount?.id, sortType, communityAddresses]);
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length > 0);
 
@@ -372,7 +424,13 @@ describe("feeds store", () => {
     const feedName = JSON.stringify([mockAccount?.id, "new", communityAddresses]);
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, "new", mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        "new",
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length > 0);
 
@@ -400,7 +458,13 @@ describe("feeds store", () => {
     const feedName = JSON.stringify([mockAccount?.id, "new", communityAddresses]);
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, "new", mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        "new",
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length > 0);
 
@@ -431,6 +495,7 @@ describe("feeds store", () => {
     act(() => {
       rendered.result.current.addFeedToStore(
         JSON.stringify([mockAccount?.id, "new", [rejectAddress]]),
+        toCommunities([rejectAddress]),
         [rejectAddress],
         "new",
         mockAccount,
@@ -450,7 +515,13 @@ describe("feeds store", () => {
     const feedName = JSON.stringify([mockAccount?.id, "new", communityAddresses]);
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, "new", mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        "new",
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length > 0);
 
@@ -468,7 +539,13 @@ describe("feeds store", () => {
     const getCommunitySpy = vi.spyOn(mockAccount.pkc, "getCommunity");
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length >= postsPerPage);
 
@@ -490,7 +567,13 @@ describe("feeds store", () => {
     const feedName = JSON.stringify([mockAccount?.id, "new", communityAddresses]);
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, "new", mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        "new",
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length > 0);
 
@@ -516,7 +599,13 @@ describe("feeds store", () => {
     const originalBlockedAddresses = mockAccount.blockedAddresses;
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, "new", mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        "new",
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length > 0);
 
@@ -538,7 +627,13 @@ describe("feeds store", () => {
     const refreshCommunity = communitiesStore.getState().refreshCommunity;
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     await waitFor(() => rendered.result.current.loadedFeeds[feedName]?.length >= postsPerPage);
 
@@ -571,6 +666,7 @@ describe("feeds store", () => {
     act(() => {
       rendered.result.current.addFeedToStore(
         feedName,
+        toCommunities(communityAddresses),
         communityAddresses,
         sortType,
         mockAccount,
@@ -588,7 +684,13 @@ describe("feeds store", () => {
     const addNextOriginal = communitiesPagesStore.getState().addNextCommunityPageToStore;
 
     act(() => {
-      rendered.result.current.addFeedToStore(feedName, communityAddresses, sortType, mockAccount);
+      rendered.result.current.addFeedToStore(
+        feedName,
+        toCommunities(communityAddresses),
+        communityAddresses,
+        sortType,
+        mockAccount,
+      );
     });
     const longWaitFor = testUtils.createWaitFor(rendered, { timeout: 10000 });
     await longWaitFor(() => rendered.result.current.loadedFeeds[feedName]?.length >= postsPerPage);

--- a/src/stores/feeds/feeds-store.test.ts
+++ b/src/stores/feeds/feeds-store.test.ts
@@ -272,6 +272,18 @@ describe("feeds store", () => {
     expect(rendered.result.current.feedsOptions[feedName]).toBeDefined();
   });
 
+  test("addFeedToStore rejects communityKeys that do not match communities", async () => {
+    await expect(
+      rendered.result.current.addFeedToStore(
+        "mismatched-community-keys",
+        toCommunities(["community address 1"]),
+        ["community address 2"],
+        "new",
+        mockAccount,
+      ),
+    ).rejects.toThrow(/communityKeys .* do not match communities/);
+  });
+
   test("duplicate feed add returns early without overwriting", async () => {
     const feedName = "duplicate-feed";
     const communityAddresses = ["community address 1"];

--- a/src/stores/feeds/feeds-store.ts
+++ b/src/stores/feeds/feeds-store.ts
@@ -18,6 +18,7 @@ import createStore from "zustand";
 import localForageLru from "../../lib/localforage-lru";
 import { communityPostsCacheExpired } from "../../lib/utils";
 import { getPkcGetCommunity } from "../../lib/pkc-compat";
+import { CommunityLookupRef, normalizeCommunityRefs } from "../../lib/community-ref";
 import accountsStore from "../accounts";
 import communitiesStore from "../communities";
 import communitiesPagesStore from "../communities-pages";
@@ -78,16 +79,51 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
 
   async addFeedToStore(
     feedName: string,
-    communityAddresses: string[],
-    sortType: string,
-    account: Account,
-    isBufferedFeed?: boolean,
-    postsPerPage?: number,
-    filter?: CommentsFilter,
-    newerThan?: number,
-    accountComments?: FeedOptionsAccountComments,
+    communityRefsOrAddresses: CommunityLookupRef[] | string[],
+    communityKeysOrSortType: string[] | string,
+    sortTypeOrAccount: string | Account,
+    accountOrIsBuffered?: Account | boolean,
+    isBufferedFeedOrPostsPerPage?: boolean | number,
+    postsPerPageOrFilter?: number | CommentsFilter,
+    filterOrNewerThan?: CommentsFilter | number,
+    newerThanOrAccountComments?: number | FeedOptionsAccountComments,
+    accountCommentsOrModQueue?: FeedOptionsAccountComments | string[],
     modQueue?: string[],
   ) {
+    let communityRefs: CommunityLookupRef[];
+    let communityKeys: string[];
+    let sortType: string;
+    let account: Account;
+    let isBufferedFeed: boolean | undefined;
+    let postsPerPage: number | undefined;
+    let filter: CommentsFilter | undefined;
+    let newerThan: number | undefined;
+    let accountComments: FeedOptionsAccountComments | undefined;
+
+    if (Array.isArray(communityKeysOrSortType)) {
+      communityRefs = communityRefsOrAddresses as CommunityLookupRef[];
+      communityKeys = communityKeysOrSortType;
+      sortType = sortTypeOrAccount as string;
+      account = accountOrIsBuffered as Account;
+      isBufferedFeed = isBufferedFeedOrPostsPerPage as boolean | undefined;
+      postsPerPage = postsPerPageOrFilter as number | undefined;
+      filter = filterOrNewerThan as CommentsFilter | undefined;
+      newerThan = newerThanOrAccountComments as number | undefined;
+      accountComments = accountCommentsOrModQueue as FeedOptionsAccountComments | undefined;
+    } else {
+      const communityAddresses = communityRefsOrAddresses as string[];
+      communityRefs = normalizeCommunityRefs(undefined, communityAddresses);
+      communityKeys = communityAddresses;
+      sortType = communityKeysOrSortType;
+      account = sortTypeOrAccount as Account;
+      isBufferedFeed = accountOrIsBuffered as boolean | undefined;
+      postsPerPage = isBufferedFeedOrPostsPerPage as number | undefined;
+      filter = postsPerPageOrFilter as CommentsFilter | undefined;
+      newerThan = filterOrNewerThan as number | undefined;
+      accountComments = newerThanOrAccountComments as FeedOptionsAccountComments | undefined;
+      modQueue = accountCommentsOrModQueue as string[] | undefined;
+    }
+
     // init here because must be called after async accounts store finished initializing
     initializeFeedsStore();
 
@@ -96,8 +132,12 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
       `feedsStore.addFeedToStore feedName '${feedName}' invalid`,
     );
     assert(
-      Array.isArray(communityAddresses),
-      `addFeedToStore.addFeedToStore communityAddresses '${communityAddresses}' invalid`,
+      Array.isArray(communityRefs),
+      `addFeedToStore.addFeedToStore communityRefs '${communityRefs}' invalid`,
+    );
+    assert(
+      Array.isArray(communityKeys),
+      `addFeedToStore.addFeedToStore communityKeys '${communityKeys}' invalid`,
     );
     assert(
       sortType && typeof sortType === "string",
@@ -147,7 +187,10 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
     }
     // to add a buffered feed, add a feed with pageNumber 0
     const feedOptions = {
-      communityAddresses,
+      communities: communityRefs,
+      communityRefs,
+      communityKeys,
+      communityAddresses: communityKeys,
       sortType,
       accountId: account.id,
       pageNumber: isBufferedFeed === true ? 0 : 1,
@@ -163,7 +206,7 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
       feedsOptions: { ...feedsOptions, [feedName]: feedOptions },
     }));
 
-    addCommunitiesToCommunitiesStore(communityAddresses, account);
+    addCommunitiesToCommunitiesStore(communityRefs, account);
 
     // update feeds right away to use the already loaded communities and pages
     // if no new communities are added by the feed, like for a sort type change,
@@ -209,7 +252,7 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
     );
     log("feedsActions.resetFeed", { feedName });
 
-    const { modQueue, sortType, communityAddresses, accountId } = feedsOptions[feedName];
+    const { modQueue, sortType, communityKeys, accountId } = feedsOptions[feedName];
     const account = accountsStore.getState().accounts[accountId];
     assert(
       account,
@@ -231,8 +274,8 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
     if (modQueue?.[0]) {
       const { communities } = communitiesStore.getState();
       const { invalidateCommunityPages } = communitiesPagesStore.getState();
-      const loadedCommunities = communityAddresses
-        .map((communityAddress: string) => communities[communityAddress])
+      const loadedCommunities = communityKeys
+        .map((communityKey: string) => communities[communityKey])
         .filter((community: Community | undefined): community is Community => Boolean(community));
       await Promise.all(
         loadedCommunities.map((community: Community) =>
@@ -242,14 +285,14 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
     }
 
     await Promise.all(
-      communityAddresses.map((communityAddress: string) =>
+      communityKeys.map((communityKey: string) =>
         communitiesStore
           .getState()
-          .refreshCommunity(communityAddress, account)
+          .refreshCommunity(communityKey, account)
           .catch((error: unknown) =>
             log.error("feedsStore.resetFeed refreshCommunity error", {
               feedName,
-              communityAddress,
+              communityAddress: communityKey,
               error,
             }),
           ),
@@ -313,6 +356,7 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
         accounts,
       );
       const feedsCommunityAddressesWithNewerPosts = getFeedsCommunityAddressesWithNewerPosts(
+        feedsOptions,
         filteredSortedFeeds,
         loadedFeeds,
         previousState.feedsCommunityAddressesWithNewerPosts,
@@ -627,12 +671,15 @@ const updateFeedsOnAccountsCommentsChange = (accountsStoreState: any) => {
   feedsStore.getState().updateFeeds();
 };
 
-const addCommunitiesToCommunitiesStore = (communityAddresses: string[], account: Account) => {
+const addCommunitiesToCommunitiesStore = (
+  communityRefs: CommunityLookupRef[],
+  account: Account,
+) => {
   const addCommunityToStore = communitiesStore.getState().addCommunityToStore;
-  for (const communityAddress of communityAddresses) {
-    addCommunityToStore(communityAddress, account).catch((error: unknown) =>
+  for (const communityRef of communityRefs) {
+    addCommunityToStore(communityRef, account).catch((error: unknown) =>
       log.error("feedsStore communitiesActions.addCommunityToStore error", {
-        communityAddress,
+        communityRef,
         error,
       }),
     );

--- a/src/stores/feeds/feeds-store.ts
+++ b/src/stores/feeds/feeds-store.ts
@@ -216,7 +216,7 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
     );
     log("feedsActions.resetFeed", { feedName });
 
-    const { modQueue, sortType, communityKeys, accountId } = feedsOptions[feedName];
+    const { modQueue, sortType, communities, communityKeys, accountId } = feedsOptions[feedName];
     const account = accountsStore.getState().accounts[accountId];
     assert(
       account,
@@ -249,14 +249,15 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
     }
 
     await Promise.all(
-      communityKeys.map((communityKey: string) =>
+      communities.map((communityRef: CommunityLookupRef, communityIndex: number) =>
         communitiesStore
           .getState()
-          .refreshCommunity(communityKey, account)
+          .refreshCommunity(communityRef, account)
           .catch((error: unknown) =>
             log.error("feedsStore.resetFeed refreshCommunity error", {
               feedName,
-              communityAddress: communityKey,
+              community: communityRef,
+              communityKey: communityKeys[communityIndex],
               error,
             }),
           ),

--- a/src/stores/feeds/feeds-store.ts
+++ b/src/stores/feeds/feeds-store.ts
@@ -18,7 +18,7 @@ import createStore from "zustand";
 import localForageLru from "../../lib/localforage-lru";
 import { communityPostsCacheExpired } from "../../lib/utils";
 import { getPkcGetCommunity } from "../../lib/pkc-compat";
-import { CommunityLookupRef } from "../../lib/community-ref";
+import { CommunityLookupRef, getCommunityRefKeys } from "../../lib/community-ref";
 import accountsStore from "../accounts";
 import communitiesStore from "../communities";
 import communitiesPagesStore from "../communities-pages";
@@ -104,6 +104,12 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
     assert(
       Array.isArray(communityKeys),
       `addFeedToStore.addFeedToStore communityKeys '${communityKeys}' invalid`,
+    );
+    const derivedCommunityKeys = getCommunityRefKeys(communities);
+    assert(
+      communityKeys.length === derivedCommunityKeys.length &&
+        communityKeys.every((communityKey, index) => communityKey === derivedCommunityKeys[index]),
+      `addFeedToStore.addFeedToStore communityKeys '${communityKeys}' do not match communities`,
     );
     assert(
       sortType && typeof sortType === "string",

--- a/src/stores/feeds/feeds-store.ts
+++ b/src/stores/feeds/feeds-store.ts
@@ -18,7 +18,7 @@ import createStore from "zustand";
 import localForageLru from "../../lib/localforage-lru";
 import { communityPostsCacheExpired } from "../../lib/utils";
 import { getPkcGetCommunity } from "../../lib/pkc-compat";
-import { CommunityLookupRef, normalizeCommunityRefs } from "../../lib/community-ref";
+import { CommunityLookupRef } from "../../lib/community-ref";
 import accountsStore from "../accounts";
 import communitiesStore from "../communities";
 import communitiesPagesStore from "../communities-pages";
@@ -40,7 +40,7 @@ import {
   getFeedsCommunitiesLoadedCount,
   getFeedsCommunitiesPostsPagesFirstUpdatedAts,
   getFilteredSortedFeeds,
-  getFeedsCommunityAddressesWithNewerPosts,
+  getFeedsCommunityKeysWithNewerPosts,
 } from "./utils";
 
 // reddit loads approximately 25 posts per page
@@ -57,7 +57,7 @@ type FeedsState = {
   updatedFeeds: Feeds;
   bufferedFeedsCommunitiesPostCounts: FeedsCommunitiesPostCounts;
   feedsHaveMore: { [feedName: string]: boolean };
-  feedsCommunityAddressesWithNewerPosts: { [feedName: string]: string[] };
+  feedsCommunityKeysWithNewerPosts: { [feedName: string]: string[] };
   addFeedToStore: Function;
   incrementFeedPageNumber: Function;
   resetFeed: Function;
@@ -75,55 +75,21 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
   updatedFeeds: {},
   bufferedFeedsCommunitiesPostCounts: {},
   feedsHaveMore: {},
-  feedsCommunityAddressesWithNewerPosts: {},
+  feedsCommunityKeysWithNewerPosts: {},
 
   async addFeedToStore(
     feedName: string,
-    communityRefsOrAddresses: CommunityLookupRef[] | string[],
-    communityKeysOrSortType: string[] | string,
-    sortTypeOrAccount: string | Account,
-    accountOrIsBuffered?: Account | boolean,
-    isBufferedFeedOrPostsPerPage?: boolean | number,
-    postsPerPageOrFilter?: number | CommentsFilter,
-    filterOrNewerThan?: CommentsFilter | number,
-    newerThanOrAccountComments?: number | FeedOptionsAccountComments,
-    accountCommentsOrModQueue?: FeedOptionsAccountComments | string[],
+    communities: CommunityLookupRef[],
+    communityKeys: string[],
+    sortType: string,
+    account: Account,
+    isBufferedFeed?: boolean,
+    postsPerPage?: number,
+    filter?: CommentsFilter,
+    newerThan?: number,
+    accountComments?: FeedOptionsAccountComments,
     modQueue?: string[],
   ) {
-    let communityRefs: CommunityLookupRef[];
-    let communityKeys: string[];
-    let sortType: string;
-    let account: Account;
-    let isBufferedFeed: boolean | undefined;
-    let postsPerPage: number | undefined;
-    let filter: CommentsFilter | undefined;
-    let newerThan: number | undefined;
-    let accountComments: FeedOptionsAccountComments | undefined;
-
-    if (Array.isArray(communityKeysOrSortType)) {
-      communityRefs = communityRefsOrAddresses as CommunityLookupRef[];
-      communityKeys = communityKeysOrSortType;
-      sortType = sortTypeOrAccount as string;
-      account = accountOrIsBuffered as Account;
-      isBufferedFeed = isBufferedFeedOrPostsPerPage as boolean | undefined;
-      postsPerPage = postsPerPageOrFilter as number | undefined;
-      filter = filterOrNewerThan as CommentsFilter | undefined;
-      newerThan = newerThanOrAccountComments as number | undefined;
-      accountComments = accountCommentsOrModQueue as FeedOptionsAccountComments | undefined;
-    } else {
-      const communityAddresses = communityRefsOrAddresses as string[];
-      communityRefs = normalizeCommunityRefs(undefined, communityAddresses);
-      communityKeys = communityAddresses;
-      sortType = communityKeysOrSortType;
-      account = sortTypeOrAccount as Account;
-      isBufferedFeed = accountOrIsBuffered as boolean | undefined;
-      postsPerPage = isBufferedFeedOrPostsPerPage as number | undefined;
-      filter = postsPerPageOrFilter as CommentsFilter | undefined;
-      newerThan = filterOrNewerThan as number | undefined;
-      accountComments = newerThanOrAccountComments as FeedOptionsAccountComments | undefined;
-      modQueue = accountCommentsOrModQueue as string[] | undefined;
-    }
-
     // init here because must be called after async accounts store finished initializing
     initializeFeedsStore();
 
@@ -132,8 +98,8 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
       `feedsStore.addFeedToStore feedName '${feedName}' invalid`,
     );
     assert(
-      Array.isArray(communityRefs),
-      `addFeedToStore.addFeedToStore communityRefs '${communityRefs}' invalid`,
+      Array.isArray(communities),
+      `addFeedToStore.addFeedToStore communities '${communities}' invalid`,
     );
     assert(
       Array.isArray(communityKeys),
@@ -187,10 +153,8 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
     }
     // to add a buffered feed, add a feed with pageNumber 0
     const feedOptions = {
-      communities: communityRefs,
-      communityRefs,
+      communities,
       communityKeys,
-      communityAddresses: communityKeys,
       sortType,
       accountId: account.id,
       pageNumber: isBufferedFeed === true ? 0 : 1,
@@ -206,7 +170,7 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
       feedsOptions: { ...feedsOptions, [feedName]: feedOptions },
     }));
 
-    addCommunitiesToCommunitiesStore(communityRefs, account);
+    addCommunitiesToCommunitiesStore(communities, account);
 
     // update feeds right away to use the already loaded communities and pages
     // if no new communities are added by the feed, like for a sort type change,
@@ -355,11 +319,11 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
         communitiesPages,
         accounts,
       );
-      const feedsCommunityAddressesWithNewerPosts = getFeedsCommunityAddressesWithNewerPosts(
+      const feedsCommunityKeysWithNewerPosts = getFeedsCommunityKeysWithNewerPosts(
         feedsOptions,
         filteredSortedFeeds,
         loadedFeeds,
-        previousState.feedsCommunityAddressesWithNewerPosts,
+        previousState.feedsCommunityKeysWithNewerPosts,
       );
       const updatedFeeds = await getUpdatedFeeds(
         feedsOptions,
@@ -376,7 +340,7 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
         updatedFeeds,
         bufferedFeedsCommunitiesPostCounts,
         feedsHaveMore,
-        feedsCommunityAddressesWithNewerPosts,
+        feedsCommunityKeysWithNewerPosts,
       }));
       log.trace("feedsStore.updateFeeds", {
         feedsOptions,
@@ -387,7 +351,7 @@ const feedsStore = createStore<FeedsState>((setState: Function, getState: Functi
         feedsHaveMore,
         communities,
         communitiesPages,
-        feedsCommunityAddressesWithNewerPosts,
+        feedsCommunityKeysWithNewerPosts,
       });
 
       // TODO: if updateFeeds was called while updateFeedsPending = true, maybe we should recall updateFeeds here

--- a/src/stores/feeds/utils.test.ts
+++ b/src/stores/feeds/utils.test.ts
@@ -936,6 +936,35 @@ describe("feeds utils", () => {
       expect(result.feed1).toBeDefined();
     });
 
+    test("skips publicKey-keyed communities when the resolved address is blocked", () => {
+      const community = {
+        name: "blocked.eth",
+        publicKey: "blocked-public-key",
+      };
+      const feedsOptions = {
+        feed1: {
+          communities: [community],
+          communityKeys: [community.publicKey],
+          sortType: "new",
+          accountId: mockAccountId,
+        },
+      };
+      const communities = {
+        [community.publicKey]: {
+          address: community.name,
+          publicKey: community.publicKey,
+          updatedAt: 1,
+          posts: { pageCids: { new: "pc1" }, pages: {} },
+        },
+      };
+      const accounts = makeMockAccounts({
+        blockedAddresses: { [community.name]: true },
+      });
+
+      const result = getFeedsHaveMore(feedsOptions, {}, communities, {}, accounts);
+      expect(result.feed1).toBe(false);
+    });
+
     test("uses modQueue when modQueue option present", () => {
       const feedsOptions = {
         feed1: {

--- a/src/stores/feeds/utils.test.ts
+++ b/src/stores/feeds/utils.test.ts
@@ -18,6 +18,9 @@ import accountsStore from "../accounts";
 
 const mockAccountId = "mock-account-id";
 
+const toCommunities = (communityKeys: string[]) =>
+  communityKeys.map((communityKey) => ({ name: communityKey }));
+
 const makeMockAccounts = (overrides: any = {}) => ({
   [mockAccountId]: {
     id: mockAccountId,
@@ -66,7 +69,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         [feedName]: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -95,7 +98,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -127,7 +130,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -140,7 +143,7 @@ describe("feeds utils", () => {
     test("skips community that has not loaded yet", () => {
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1", "sub2"],
+          communities: toCommunities(["sub1", "sub2"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -183,7 +186,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -217,7 +220,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -258,7 +261,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
           modQueue: ["pendingApproval"],
@@ -294,7 +297,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["music-posting.bso"],
+          communities: toCommunities(["music-posting.bso"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -323,7 +326,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: [blockedSubAddr],
+          communities: toCommunities([blockedSubAddr]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -360,7 +363,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -392,7 +395,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
           filter: { filter: (p: any) => p.cid !== "c2", key: "exclude-c2" },
@@ -433,7 +436,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1", "sub2"],
+          communities: toCommunities(["sub1", "sub2"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -463,7 +466,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -493,7 +496,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -521,7 +524,7 @@ describe("feeds utils", () => {
       };
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -547,7 +550,7 @@ describe("feeds utils", () => {
       const recentTs = Math.floor(Date.now() / 1000) - 100;
       const feedsOptions = {
         [feedName]: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           accountId: mockAccountId,
           accountComments: { newerThan: 3600, append: false },
         },
@@ -573,7 +576,7 @@ describe("feeds utils", () => {
       const recentTs = Math.floor(Date.now() / 1000) - 100;
       const feedsOptions = {
         [feedName]: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           accountId: mockAccountId,
           accountComments: { newerThan: 3600, append: false },
         },
@@ -610,7 +613,7 @@ describe("feeds utils", () => {
       const recentTs = Math.floor(Date.now() / 1000) - 100;
       const feedsOptions = {
         [feedName]: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           accountId: mockAccountId,
           accountComments: { newerThan: 3600, append: true },
         },
@@ -643,7 +646,7 @@ describe("feeds utils", () => {
       const recentTs = Math.floor(Date.now() / 1000) - 100;
       const feedsOptions = {
         [feedName]: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           accountId: mockAccountId,
           accountComments: { newerThan: 3600, append: false },
         },
@@ -677,7 +680,7 @@ describe("feeds utils", () => {
 
   describe("blocked addresses/cids no-change false branches", () => {
     test("feedsHaveChangedBlockedAddresses returns true when changed address is in feed communities", () => {
-      const feedsOptions = { feeds1: { communityAddresses: ["blocked-x"] } };
+      const feedsOptions = { feeds1: { communities: toCommunities(["blocked-x"]) } };
       const bufferedFeeds = { feeds1: [] };
       const blockedAddresses = ["blocked-x"];
       const previousBlockedAddresses: string[] = [];
@@ -691,7 +694,7 @@ describe("feeds utils", () => {
     });
 
     test("feedsHaveChangedBlockedAddresses returns false when changed blocked not in feeds", () => {
-      const feedsOptions = { feeds1: { communityAddresses: ["sub-a"] } };
+      const feedsOptions = { feeds1: { communities: toCommunities(["sub-a"]) } };
       const bufferedFeeds = {
         feeds1: [{ cid: "c1", communityAddress: "sub-a", author: { address: "addr-a" } }],
       };
@@ -707,7 +710,7 @@ describe("feeds utils", () => {
     });
 
     test("feedsHaveChangedBlockedCids returns false when changed blocked cids not in feeds", () => {
-      const feedsOptions = { feeds1: { communityAddresses: ["sub-a"] } };
+      const feedsOptions = { feeds1: { communities: toCommunities(["sub-a"]) } };
       const bufferedFeeds = {
         feeds1: [{ cid: "c1", communityAddress: "sub-a" }],
       };
@@ -723,7 +726,7 @@ describe("feeds utils", () => {
     });
 
     test("feedsHaveChangedBlockedCids returns true when cid in feed is blocked", () => {
-      const feedsOptions = { feeds1: { communityAddresses: ["sub-a"] } };
+      const feedsOptions = { feeds1: { communities: toCommunities(["sub-a"]) } };
       const bufferedFeeds = {
         feeds1: [{ cid: "blocked-cid-x", communityAddress: "sub-a" }],
       };
@@ -751,7 +754,7 @@ describe("feeds utils", () => {
     test("returns loadedFeeds when no missing posts and no account comments change", async () => {
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
           pageNumber: 1,
@@ -779,7 +782,7 @@ describe("feeds utils", () => {
     test("adds missing posts from buffered feed", async () => {
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
           pageNumber: 2,
@@ -811,7 +814,7 @@ describe("feeds utils", () => {
       const feedName = "feed1";
       const feedsOptions = {
         [feedName]: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
           pageNumber: 2,
@@ -910,7 +913,7 @@ describe("feeds utils", () => {
     test("continues when community address is blocked", () => {
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["blocked-sub", "sub2"],
+          communities: toCommunities(["blocked-sub", "sub2"]),
           sortType: "new",
           accountId: mockAccountId,
         },
@@ -936,7 +939,7 @@ describe("feeds utils", () => {
     test("uses modQueue when modQueue option present", () => {
       const feedsOptions = {
         feed1: {
-          communityAddresses: ["sub1"],
+          communities: toCommunities(["sub1"]),
           sortType: "new",
           accountId: mockAccountId,
           modQueue: ["approved"],
@@ -965,7 +968,7 @@ describe("feeds utils", () => {
 
   describe("getFeedsCommunitiesFirstPageCids", () => {
     test("includes pageCids from posts and modQueue", () => {
-      const feedsOptions = { f1: { communityAddresses: ["s1"] } };
+      const feedsOptions = { f1: { communities: toCommunities(["s1"]) } };
       const communities = new Map([
         [
           "s1",
@@ -1032,7 +1035,7 @@ describe("feeds utils", () => {
 
   describe("feedsHaveChangedBlockedAddresses author address", () => {
     test("returns true when post author address is in changed blocked", () => {
-      const feedsOptions = { f1: { communityAddresses: ["sub-a"] } };
+      const feedsOptions = { f1: { communities: toCommunities(["sub-a"]) } };
       const bufferedFeeds = {
         f1: [{ cid: "c1", communityAddress: "sub-a", author: { address: "blocked-author" } }],
       };

--- a/src/stores/feeds/utils.ts
+++ b/src/stores/feeds/utils.ts
@@ -17,10 +17,33 @@ import { getCommunityPages, getCommunityFirstPageCid } from "../communities-page
 import accountsStore from "../accounts";
 import feedSorter from "./feed-sorter";
 import { communityPostsCacheExpired, commentIsValid, removeInvalidComments } from "../../lib/utils";
-import { areEquivalentCommunityAddresses } from "../../lib/community-address";
 import { getCommentCommunityAddress, normalizeCommentCommunityAddress } from "../../lib/pkc-compat";
+import {
+  CommunityLookupRef,
+  communityAddressToRef,
+  doesAddressMatchCommunityRef,
+  getCommunityRefKeys,
+  getMatchingCommunityRefKeys,
+} from "../../lib/community-ref";
 import Logger from "@pkc/pkc-logger";
 const log = Logger("bitsocial-react-hooks:feeds:stores");
+
+type FeedOptionsWithLegacyCommunityAddresses = Partial<FeedOptions> & {
+  communityAddresses?: string[];
+  communityRefs?: CommunityLookupRef[];
+};
+
+const getFeedCommunityRefs = (
+  feedOptions: FeedOptionsWithLegacyCommunityAddresses,
+): CommunityLookupRef[] =>
+  feedOptions.communities ||
+  feedOptions.communityRefs ||
+  (feedOptions.communityAddresses || []).map(communityAddressToRef);
+
+const getFeedCommunityKeys = (feedOptions: FeedOptionsWithLegacyCommunityAddresses) =>
+  feedOptions.communityKeys ||
+  feedOptions.communityAddresses ||
+  getCommunityRefKeys(getFeedCommunityRefs(feedOptions));
 
 const getCommentFreshness = (comment: Comment | undefined) =>
   Math.max(comment?.updatedAt ?? 0, comment?.timestamp ?? 0, 0);
@@ -38,7 +61,8 @@ const commentMatchesModQueue = (comment: Comment | undefined, modQueue?: string[
 
 const getFeedPost = (
   post: Comment,
-  communityAddress: string,
+  communityRef: CommunityLookupRef,
+  community: Community,
   modQueue?: string[],
   freshestComments?: { [commentCid: string]: Comment },
 ) => {
@@ -47,7 +71,7 @@ const getFeedPost = (
     ? normalizeCommentCommunityAddress(freshestComments?.[post.cid])
     : undefined;
   const postCommunityAddress = getCommentCommunityAddress(normalizedPost);
-  if (!areEquivalentCommunityAddresses(postCommunityAddress, communityAddress)) {
+  if (!doesAddressMatchCommunityRef(postCommunityAddress, communityRef, community)) {
     return;
   }
   if (!commentMatchesModQueue(normalizedPost, modQueue)) {
@@ -63,7 +87,11 @@ const getFeedPost = (
     return;
   }
   if (
-    !areEquivalentCommunityAddresses(getCommentCommunityAddress(freshestComment), communityAddress)
+    !doesAddressMatchCommunityRef(
+      getCommentCommunityAddress(freshestComment),
+      communityRef,
+      community,
+    )
   ) {
     return;
   }
@@ -125,8 +153,9 @@ export const getFilteredSortedFeeds = (
   // calculate each feed
   let feeds: Feeds = {};
   for (const feedName in feedsOptions) {
-    let { communityAddresses, sortType, accountId, filter, newerThan, modQueue } =
-      feedsOptions[feedName];
+    const communityRefs = getFeedCommunityRefs(feedsOptions[feedName]);
+    const communityKeys = getFeedCommunityKeys(feedsOptions[feedName]);
+    let { sortType, accountId, filter, newerThan, modQueue } = feedsOptions[feedName];
     const newerThanTimestamp = newerThan ? Math.floor(Date.now() / 1000) - newerThan : undefined;
 
     let pageType = "posts";
@@ -140,28 +169,30 @@ export const getFilteredSortedFeeds = (
     const bufferedFeedPosts = [];
 
     // add each comment from each page, do not filter at this stage, filter after sorting
-    for (const communityAddress of communityAddresses) {
+    for (const [communityIndex, communityKey] of communityKeys.entries()) {
+      const communityRef = communityRefs[communityIndex];
       // community hasn't loaded yet
-      if (!communities[communityAddress]) {
+      const community = communities[communityKey];
+      if (!community || !communityRef) {
         continue;
       }
 
       // if cache is expired and has internet access, don't use, wait for next community update
-      if (communityPostsCacheExpired(communities[communityAddress]) && window.navigator.onLine) {
+      if (communityPostsCacheExpired(community) && window.navigator.onLine) {
         continue;
       }
 
       // use community preloaded posts if any
-      const preloadedPosts = getPreloadedPosts(communities[communityAddress], sortType);
+      const preloadedPosts = getPreloadedPosts(community, sortType);
       if (preloadedPosts) {
         for (const post of preloadedPosts) {
           // posts are manually validated, could have fake communityAddress
           if (
-            !areEquivalentCommunityAddresses(getCommentCommunityAddress(post), communityAddress)
+            !doesAddressMatchCommunityRef(getCommentCommunityAddress(post), communityRef, community)
           ) {
             break;
           }
-          const nextPost = getFeedPost(post, communityAddress, modQueue, freshestComments);
+          const nextPost = getFeedPost(post, communityRef, community, modQueue, freshestComments);
           if (nextPost) {
             bufferedFeedPosts.push(nextPost);
           }
@@ -170,7 +201,7 @@ export const getFilteredSortedFeeds = (
 
       // add all posts from community pages
       const communityPages = getCommunityPages(
-        communities[communityAddress],
+        community,
         sortType,
         communitiesPages,
         pageType,
@@ -181,11 +212,15 @@ export const getFilteredSortedFeeds = (
           for (const post of communityPage.comments) {
             // posts are manually validated, could have fake communityAddress
             if (
-              !areEquivalentCommunityAddresses(getCommentCommunityAddress(post), communityAddress)
+              !doesAddressMatchCommunityRef(
+                getCommentCommunityAddress(post),
+                communityRef,
+                community,
+              )
             ) {
               break;
             }
-            const nextPost = getFeedPost(post, communityAddress, modQueue, freshestComments);
+            const nextPost = getFeedPost(post, communityRef, community, modQueue, freshestComments);
             if (nextPost) {
               bufferedFeedPosts.push(nextPost);
             }
@@ -216,7 +251,7 @@ export const getFilteredSortedFeeds = (
 
       // if a feed has more than 1 sub, don't include pinned posts
       // TODO: add test to check if pinned are filtered
-      if (post.pinned && communityAddresses.length > 1) {
+      if (post.pinned && communityKeys.length > 1) {
         continue;
       }
 
@@ -338,11 +373,8 @@ export const addAccountsComments = (feedsOptions: FeedsOptions, loadedFeeds: Fee
   let loadedFeedsChanged = false;
   const accountsComments = accountsStore.getState().accountsComments || {};
   for (const feedName in feedsOptions) {
-    const {
-      accountId,
-      accountComments: accountCommentsOptions,
-      communityAddresses,
-    } = feedsOptions[feedName];
+    const { accountId, accountComments: accountCommentsOptions } = feedsOptions[feedName];
+    const communityRefs = getFeedCommunityRefs(feedsOptions[feedName]);
     const { newerThan, append } = accountCommentsOptions || {};
     if (!newerThan) {
       continue;
@@ -351,7 +383,6 @@ export const addAccountsComments = (feedsOptions: FeedsOptions, loadedFeeds: Fee
       newerThan === Infinity ? 0 : Math.floor(Date.now() / 1000) - newerThan;
     const isNewerThan = (post: Comment) => post.timestamp > newerThanTimestamp;
 
-    const communityAddressesSet = new Set(communityAddresses);
     const accountComments = accountsComments[accountId] || [];
     const accountPosts = accountComments.filter((comment) => {
       // is a reply, not a post
@@ -361,7 +392,9 @@ export const addAccountsComments = (feedsOptions: FeedsOptions, loadedFeeds: Fee
       if (!isNewerThan(comment)) {
         return false;
       }
-      return communityAddressesSet.has(getCommentCommunityAddress(comment) || "");
+      return (
+        getMatchingCommunityRefKeys(communityRefs, getCommentCommunityAddress(comment)).length > 0
+      );
     });
     const validAccountIndices = new Set(accountPosts.map((p) => p.index));
     const accountCidToPost = new Map<string, Comment>();
@@ -535,6 +568,7 @@ export const getUpdatedFeeds = async (
 // find with communities have posts newer (or ranked higher) than the loaded feeds
 // can be used to display "new posts in x, y, z subs" alert, like on twitter
 export const getFeedsCommunityAddressesWithNewerPosts = (
+  feedsOptions: FeedsOptions,
   filteredSortedFeeds: Feeds,
   loadedFeeds: Feeds,
   previousFeedsCommunityAddressesWithNewerPosts: { [feedName: string]: string[] },
@@ -555,7 +589,10 @@ export const getFeedsCommunityAddressesWithNewerPosts = (
       if (!cidsInLoadedFeed.has(post.cid)) {
         const postCommunityAddress = getCommentCommunityAddress(post);
         if (postCommunityAddress) {
-          communityAddressesWithNewerPostsSet.add(postCommunityAddress);
+          getMatchingCommunityRefKeys(
+            getFeedCommunityRefs(feedsOptions[feedName] || {}),
+            postCommunityAddress,
+          ).forEach((communityKey) => communityAddressesWithNewerPostsSet.add(communityKey));
         }
       }
     }
@@ -582,14 +619,21 @@ export const getFeedsCommunityAddressesWithNewerPosts = (
 export const getFeedsCommunitiesPostCounts = (feedsOptions: FeedsOptions, feeds: Feeds) => {
   const feedsCommunitiesPostCounts: FeedsCommunitiesPostCounts = {};
   for (const feedName in feedsOptions) {
+    const communityKeys = getFeedCommunityKeys(feedsOptions[feedName]);
+    const communityRefs = getFeedCommunityRefs(feedsOptions[feedName]);
     feedsCommunitiesPostCounts[feedName] = {};
-    for (const communityAddress of feedsOptions[feedName].communityAddresses) {
-      feedsCommunitiesPostCounts[feedName][communityAddress] = 0;
+    for (const communityKey of communityKeys) {
+      feedsCommunitiesPostCounts[feedName][communityKey] = 0;
     }
     for (const comment of feeds[feedName] || []) {
       const commentCommunityAddress = getCommentCommunityAddress(comment);
       if (commentCommunityAddress) {
-        feedsCommunitiesPostCounts[feedName][commentCommunityAddress]++;
+        getMatchingCommunityRefKeys(communityRefs, commentCommunityAddress).forEach(
+          (communityKey) => {
+            feedsCommunitiesPostCounts[feedName][communityKey] =
+              (feedsCommunitiesPostCounts[feedName][communityKey] || 0) + 1;
+          },
+        );
       }
     }
   }
@@ -614,7 +658,9 @@ export const getFeedsHaveMore = (
       continue feedsLoop;
     }
 
-    let { communityAddresses, sortType, accountId, modQueue } = feedsOptions[feedName];
+    const communityRefs = getFeedCommunityRefs(feedsOptions[feedName]);
+    const communityKeys = getFeedCommunityKeys(feedsOptions[feedName]);
+    let { sortType, accountId, modQueue } = feedsOptions[feedName];
 
     let pageType = "posts";
     if (modQueue?.[0]) {
@@ -623,13 +669,13 @@ export const getFeedsHaveMore = (
       pageType = "modQueue";
     }
 
-    communityAddressesLoop: for (const communityAddress of communityAddresses) {
+    communityAddressesLoop: for (const [communityIndex, communityKey] of communityKeys.entries()) {
       // don't consider the sub if the address is blocked
-      if (accounts[accountId]?.blockedAddresses[communityAddress]) {
+      if (accounts[accountId]?.blockedAddresses[communityKey]) {
         continue communityAddressesLoop;
       }
 
-      const community = communities[communityAddress];
+      const community = communities[communityKey];
       // if at least 1 community hasn't loaded yet, then the feed still has more
       if (!community?.updatedAt) {
         feedsHaveMore[feedName] = true;
@@ -673,7 +719,7 @@ export const getFeedsCommunities = (feedsOptions: FeedsOptions, communities: Com
   // find all feeds communities
   const feedsCommunityAddresses = new Set<string>();
   Object.keys(feedsOptions).forEach((i) =>
-    feedsOptions[i].communityAddresses.forEach((a) => feedsCommunityAddresses.add(a)),
+    getFeedCommunityKeys(feedsOptions[i]).forEach((a) => feedsCommunityAddresses.add(a)),
   );
 
   // use map for performance increase when checking size
@@ -811,14 +857,16 @@ export const feedsHaveChangedBlockedAddresses = (
     .concat(previousBlockedAddresses.filter((x) => !blockedAddresses.includes(x)));
 
   // if changed blocked addresses arent used in the feeds, do nothing
-  const feedsCommunityAddresses = new Set<string>();
-  Object.keys(feedsOptions).forEach((i) =>
-    feedsOptions[i].communityAddresses.forEach((a) => feedsCommunityAddresses.add(a)),
-  );
   for (const address of changedBlockedAddresses) {
-    // a changed address is used in the feed, update feeds
-    if (feedsCommunityAddresses.has(address)) {
-      return true;
+    for (const feedName in feedsOptions) {
+      const feedOptions = feedsOptions[feedName];
+      if (
+        getMatchingCommunityRefKeys(getFeedCommunityRefs(feedOptions), address).some(
+          (communityKey) => getFeedCommunityKeys(feedOptions).includes(communityKey),
+        )
+      ) {
+        return true;
+      }
     }
   }
 

--- a/src/stores/feeds/utils.ts
+++ b/src/stores/feeds/utils.ts
@@ -657,12 +657,18 @@ export const getFeedsHaveMore = (
     }
 
     communityKeysLoop: for (const [communityIndex, communityKey] of communityKeys.entries()) {
+      const community = communities[communityKey];
+      const communityRef = communityRefs[communityIndex];
+      const isBlockedCommunity = Object.keys(accounts[accountId]?.blockedAddresses || {}).some(
+        (blockedAddress) =>
+          communityRef && doesAddressMatchCommunityRef(blockedAddress, communityRef, community),
+      );
+
       // don't consider the sub if the address is blocked
-      if (accounts[accountId]?.blockedAddresses[communityKey]) {
+      if (isBlockedCommunity) {
         continue communityKeysLoop;
       }
 
-      const community = communities[communityKey];
       // if at least 1 community hasn't loaded yet, then the feed still has more
       if (!community?.updatedAt) {
         feedsHaveMore[feedName] = true;

--- a/src/stores/feeds/utils.ts
+++ b/src/stores/feeds/utils.ts
@@ -20,7 +20,6 @@ import { communityPostsCacheExpired, commentIsValid, removeInvalidComments } fro
 import { getCommentCommunityAddress, normalizeCommentCommunityAddress } from "../../lib/pkc-compat";
 import {
   CommunityLookupRef,
-  communityAddressToRef,
   doesAddressMatchCommunityRef,
   getCommunityRefKeys,
   getMatchingCommunityRefKeys,
@@ -28,22 +27,11 @@ import {
 import Logger from "@pkc/pkc-logger";
 const log = Logger("bitsocial-react-hooks:feeds:stores");
 
-type FeedOptionsWithLegacyCommunityAddresses = Partial<FeedOptions> & {
-  communityAddresses?: string[];
-  communityRefs?: CommunityLookupRef[];
-};
+const getFeedCommunityRefs = (feedOptions: Partial<FeedOptions>): CommunityLookupRef[] =>
+  feedOptions.communities || [];
 
-const getFeedCommunityRefs = (
-  feedOptions: FeedOptionsWithLegacyCommunityAddresses,
-): CommunityLookupRef[] =>
-  feedOptions.communities ||
-  feedOptions.communityRefs ||
-  (feedOptions.communityAddresses || []).map(communityAddressToRef);
-
-const getFeedCommunityKeys = (feedOptions: FeedOptionsWithLegacyCommunityAddresses) =>
-  feedOptions.communityKeys ||
-  feedOptions.communityAddresses ||
-  getCommunityRefKeys(getFeedCommunityRefs(feedOptions));
+const getFeedCommunityKeys = (feedOptions: Partial<FeedOptions>) =>
+  feedOptions.communityKeys || getCommunityRefKeys(getFeedCommunityRefs(feedOptions));
 
 const getCommentFreshness = (comment: Comment | undefined) =>
   Math.max(comment?.updatedAt ?? 0, comment?.timestamp ?? 0, 0);
@@ -567,20 +555,20 @@ export const getUpdatedFeeds = async (
 
 // find with communities have posts newer (or ranked higher) than the loaded feeds
 // can be used to display "new posts in x, y, z subs" alert, like on twitter
-export const getFeedsCommunityAddressesWithNewerPosts = (
+export const getFeedsCommunityKeysWithNewerPosts = (
   feedsOptions: FeedsOptions,
   filteredSortedFeeds: Feeds,
   loadedFeeds: Feeds,
-  previousFeedsCommunityAddressesWithNewerPosts: { [feedName: string]: string[] },
+  previousFeedsCommunityKeysWithNewerPosts: { [feedName: string]: string[] },
 ) => {
-  const feedsCommunityAddressesWithNewerPosts: { [feedName: string]: string[] } = {};
+  const feedsCommunityKeysWithNewerPosts: { [feedName: string]: string[] } = {};
   for (const feedName in loadedFeeds) {
     const loadedFeed = loadedFeeds[feedName];
     const cidsInLoadedFeed = new Set();
     for (const post of loadedFeed) {
       cidsInLoadedFeed.add(post.cid);
     }
-    const communityAddressesWithNewerPostsSet = new Set<string>();
+    const communityKeysWithNewerPostsSet = new Set<string>();
     for (const [i, post] of filteredSortedFeeds[feedName].entries()) {
       if (i >= loadedFeed.length) {
         break;
@@ -592,27 +580,26 @@ export const getFeedsCommunityAddressesWithNewerPosts = (
           getMatchingCommunityRefKeys(
             getFeedCommunityRefs(feedsOptions[feedName] || {}),
             postCommunityAddress,
-          ).forEach((communityKey) => communityAddressesWithNewerPostsSet.add(communityKey));
+          ).forEach((communityKey) => communityKeysWithNewerPostsSet.add(communityKey));
         }
       }
     }
-    const communityAddressesWithNewerPosts = [...communityAddressesWithNewerPostsSet];
+    const communityKeysWithNewerPosts = [...communityKeysWithNewerPostsSet];
 
     // don't update the array if the data is the same to avoid rerenders
-    const previousCommunityAddressesWithNewerPosts =
-      previousFeedsCommunityAddressesWithNewerPosts[feedName] || [];
+    const previousCommunityKeysWithNewerPosts =
+      previousFeedsCommunityKeysWithNewerPosts[feedName] || [];
     if (
-      communityAddressesWithNewerPosts.length === previousCommunityAddressesWithNewerPosts.length &&
-      communityAddressesWithNewerPosts.toString() ===
-        previousCommunityAddressesWithNewerPosts.toString()
+      communityKeysWithNewerPosts.length === previousCommunityKeysWithNewerPosts.length &&
+      communityKeysWithNewerPosts.toString() === previousCommunityKeysWithNewerPosts.toString()
     ) {
-      feedsCommunityAddressesWithNewerPosts[feedName] =
-        previousFeedsCommunityAddressesWithNewerPosts[feedName];
+      feedsCommunityKeysWithNewerPosts[feedName] =
+        previousFeedsCommunityKeysWithNewerPosts[feedName];
     } else {
-      feedsCommunityAddressesWithNewerPosts[feedName] = communityAddressesWithNewerPosts;
+      feedsCommunityKeysWithNewerPosts[feedName] = communityKeysWithNewerPosts;
     }
   }
-  return feedsCommunityAddressesWithNewerPosts;
+  return feedsCommunityKeysWithNewerPosts;
 };
 
 // find how many posts are left in each communities in a buffereds feeds
@@ -669,10 +656,10 @@ export const getFeedsHaveMore = (
       pageType = "modQueue";
     }
 
-    communityAddressesLoop: for (const [communityIndex, communityKey] of communityKeys.entries()) {
+    communityKeysLoop: for (const [communityIndex, communityKey] of communityKeys.entries()) {
       // don't consider the sub if the address is blocked
       if (accounts[accountId]?.blockedAddresses[communityKey]) {
-        continue communityAddressesLoop;
+        continue communityKeysLoop;
       }
 
       const community = communities[communityKey];
@@ -693,7 +680,7 @@ export const getFeedsHaveMore = (
       // should we try to use another sort type by default, like 'hot', or should we just ignore it?
       // 'continue' to ignore it for now
       if (!firstPageCid) {
-        continue communityAddressesLoop;
+        continue communityKeysLoop;
       }
       const pages = getCommunityPages(community, sortType, communitiesPages, pageType, accountId);
       // if first page isn't loaded yet, then the feed still has more

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,16 @@ export interface NameResolverInfo {
   providerLabel: string;
 }
 
+export type CommunityIdentifier =
+  | {
+      name: string;
+      publicKey?: string;
+    }
+  | {
+      name?: string;
+      publicKey: string;
+    };
+
 // useAccount(options): result
 export interface UseAccountOptions extends Options {}
 export interface UseAccountResult extends Result, Account {}
@@ -189,14 +199,14 @@ export interface UseEditedCommentResult extends Result {
 
 // useCommunity(options): result
 export interface UseCommunityOptions extends Options {
-  communityAddress?: string;
+  community?: CommunityIdentifier;
   onlyIfCached?: boolean;
 }
 export interface UseCommunityResult extends Result, Community {}
 
 // useCommunities(options): result
 export interface UseCommunitiesOptions extends Options {
-  communityAddresses?: string[];
+  communities?: CommunityIdentifier[];
   onlyIfCached?: boolean;
 }
 export interface UseCommunitiesResult extends Result {
@@ -205,7 +215,7 @@ export interface UseCommunitiesResult extends Result {
 
 // useCommunityStats(options): result
 export interface UseCommunityStatsOptions extends Options {
-  communityAddress?: string;
+  community?: CommunityIdentifier;
   onlyIfCached?: boolean;
 }
 export interface UseCommunityStatsResult extends Result, CommunityStats {}
@@ -222,7 +232,7 @@ export interface UseResolvedCommunityAddressResult extends Result {
 
 // useFeed(options): result
 export interface UseFeedOptions extends Options {
-  communityAddresses: string[];
+  communities?: CommunityIdentifier[];
   sortType?: string;
   postsPerPage?: number;
   newerThan?: number;
@@ -234,7 +244,7 @@ export interface UseFeedResult extends Result {
   feed: Comment[];
   hasMore: boolean;
   loadMore(): Promise<void>;
-  communityAddressesWithNewerPosts: string[];
+  communityKeysWithNewerPosts: string[];
   reset(): Promise<void>;
 }
 
@@ -540,7 +550,7 @@ export interface UseClientsStatesResult extends Result {
 }
 
 export interface UseCommunitiesStatesOptions extends Options {
-  communityAddresses?: string[];
+  communities?: CommunityIdentifier[];
 }
 export interface UseCommunitiesStatesResult extends Result {
   states: { [state: string]: { communityAddresses: string[]; clientUrls: string[] } };
@@ -652,7 +662,11 @@ export type AccountPublicationsFilter = (
 export type Feed = Comment[];
 export type Feeds = { [feedName: string]: Feed };
 export type FeedOptions = {
-  communityAddresses: string[];
+  communities: CommunityIdentifier[];
+  // Internal compatibility fields for store helpers/tests. Public hook options do not accept these.
+  communityRefs?: CommunityIdentifier[];
+  communityAddresses?: string[];
+  communityKeys: string[];
   sortType: string;
   accountId: string;
   pageNumber: number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -663,9 +663,6 @@ export type Feed = Comment[];
 export type Feeds = { [feedName: string]: Feed };
 export type FeedOptions = {
   communities: CommunityIdentifier[];
-  // Internal compatibility fields for store helpers/tests. Public hook options do not accept these.
-  communityRefs?: CommunityIdentifier[];
-  communityAddresses?: string[];
   communityKeys: string[];
   sortType: string;
   accountId: string;

--- a/test/browser-e2e/accounts.test.js
+++ b/test/browser-e2e/accounts.test.js
@@ -24,6 +24,8 @@ const adminRoleSigner = signers[1];
 
 const isBase64 = (testString) =>
   /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}))?$/gm.test(testString);
+const toCommunity = (name) => (name ? { name } : undefined);
+const toCommunities = (names) => names?.map((name) => ({ name }));
 
 // large value for manual debugging
 const timeout = 600000;
@@ -119,10 +121,10 @@ for (const pkcOptionsType in pkcOptionsTypes) {
           rendered = renderHook((communityAddress) => {
             const account = useAccount();
             const { accountCommunities } = useAccountCommunities();
-            const community = useCommunity({ communityAddress });
-            const communityAddresses = communityAddress ? [communityAddress] : undefined;
-            const modQueue = useFeed({ communityAddresses, modQueue: ["pendingApproval"] });
-            const feed = useFeed({ communityAddresses });
+            const community = useCommunity({ community: toCommunity(communityAddress) });
+            const communities = toCommunities(communityAddress ? [communityAddress] : undefined);
+            const modQueue = useFeed({ communities, modQueue: ["pendingApproval"] });
+            const feed = useFeed({ communities });
             return { account, accountCommunities, community, modQueue, feed, ...accountsActions };
           });
           rendered.detach();
@@ -424,7 +426,7 @@ for (const pkcOptionsType in pkcOptionsTypes) {
       beforeAll(async () => {
         rendered = renderHook((communityAddress) => {
           const account = useAccount();
-          const community = useCommunity({ communityAddress });
+          const community = useCommunity({ community: toCommunity(communityAddress) });
           return { account, community, ...accountsActions };
         });
         rendered.detach();

--- a/test/browser-e2e/communities.test.js
+++ b/test/browser-e2e/communities.test.js
@@ -13,6 +13,7 @@ import { offlineIpfs, pubsubIpfs, pkcRpc } from "../test-server/config";
 const timeout = 600000;
 const isBase64 = (testString) =>
   /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}))?$/gm.test(testString);
+const toCommunity = (name) => (name ? { name } : undefined);
 
 // run tests using pkc options gateway and httpClient
 const localGatewayUrl = `http://localhost:${offlineIpfs.gatewayPort}`;
@@ -70,7 +71,7 @@ for (const pkcOptionsType in pkcOptionsTypes) {
       beforeAll(async () => {
         rendered = renderHook(({ communityAddress, commentCid } = {}) => {
           const account = useAccount();
-          const community = useCommunity({ communityAddress });
+          const community = useCommunity({ community: toCommunity(communityAddress) });
           const { accountVotes } = useAccountVotes();
           const comment = useComment({ commentCid });
           return { account, community, comment, accountVotes, ...accountsActions };

--- a/test/browser-e2e/feeds.test.js
+++ b/test/browser-e2e/feeds.test.js
@@ -16,6 +16,7 @@ import signers from "../fixtures/signers";
 const communityAddress = signers[0].address;
 const isBase64 = (testString) =>
   /^([0-9a-zA-Z+/]{4})*(([0-9a-zA-Z+/]{2}==)|([0-9a-zA-Z+/]{3}))?$/gm.test(testString);
+const toCommunities = (names) => names?.map((name) => ({ name }));
 
 // large value for manual debugging
 const timeout = 600000;
@@ -110,19 +111,19 @@ for (const pkcOptionsType in pkcOptionsTypes) {
     it("change sort type", async () => {
       console.log(`starting feeds tests (${pkcOptionsType})`);
 
-      rendered.rerender({ communityAddresses: [communityAddress], sortType: "hot" });
+      rendered.rerender({ communities: toCommunities([communityAddress]), sortType: "hot" });
       await waitFor(() => !!rendered.result.current.feed[0].cid);
       expect(rendered.result.current.feed[0].communityAddress).to.equal(communityAddress);
       console.log("after first render");
 
       // reset
-      rendered.rerender({ communityAddresses: [] });
+      rendered.rerender({ communities: [] });
       await waitFor(() => rendered.result.current.feed.length === 0);
       expect(rendered.result.current.feed.length).to.equal(0);
       console.log("after second render");
 
       // change sort type
-      rendered.rerender({ communityAddresses: [communityAddress], sortType: "new" });
+      rendered.rerender({ communities: toCommunities([communityAddress]), sortType: "new" });
       await waitFor(() => !!rendered.result.current.feed[0].cid);
       expect(rendered.result.current.feed[0].communityAddress).to.equal(communityAddress);
     });
@@ -136,7 +137,7 @@ for (const pkcOptionsType in pkcOptionsTypes) {
       // utility directly instead — the hook is a thin wrapper around it.
       const { commentIsValid } = await import("../../dist/lib/utils/utils");
 
-      rendered.rerender({ communityAddresses: [communityAddress], sortType: "hot" });
+      rendered.rerender({ communities: toCommunities([communityAddress]), sortType: "hot" });
       await waitFor(() => !!rendered.result.current.feed[0]?.cid);
       expect(rendered.result.current.feed[0].communityAddress).to.equal(communityAddress);
       const comment = rendered.result.current.feed[0];

--- a/test/browser-pkc-js-mock-content/pkc-js-mock-content.test.js
+++ b/test/browser-pkc-js-mock-content/pkc-js-mock-content.test.js
@@ -22,6 +22,8 @@ import { renderHook } from "../test-utils";
 import testUtils from "../../dist/lib/test-utils";
 
 const timeout = 180_000;
+const toCommunity = (name) => (name ? { name } : undefined);
+const toCommunities = (names) => names?.map((name) => ({ name }));
 
 describe("mock content", () => {
   beforeAll(() => {
@@ -90,7 +92,9 @@ describe("mock content", () => {
   });
 
   it("use communities", async () => {
-    const rendered = renderHook((communityAddress) => useCommunity({ communityAddress }));
+    const rendered = renderHook((communityAddress) =>
+      useCommunity({ community: toCommunity(communityAddress) }),
+    );
     const waitFor = testUtils.createWaitFor(rendered, { timeout });
 
     rendered.rerender("anything2.eth");
@@ -129,7 +133,9 @@ describe("mock content", () => {
 
     // test getting from db
     await testUtils.resetStores();
-    const rendered2 = renderHook((communityAddress) => useCommunity({ communityAddress }));
+    const rendered2 = renderHook((communityAddress) =>
+      useCommunity({ community: toCommunity(communityAddress) }),
+    );
 
     rendered2.rerender("anything2");
     await waitFor(() => typeof rendered2.result.current.updatedAt === "number");
@@ -144,7 +150,7 @@ describe("mock content", () => {
 
   it("use feed hot", async () => {
     const rendered = renderHook((communityAddresses) =>
-      useFeed({ communityAddresses, sortType: "hot" }),
+      useFeed({ communities: toCommunities(communityAddresses), sortType: "hot" }),
     );
     const waitFor = testUtils.createWaitFor(rendered, { timeout });
 
@@ -172,7 +178,7 @@ describe("mock content", () => {
 
   it("use feed new", async () => {
     const rendered = renderHook((communityAddresses) =>
-      useFeed({ communityAddresses, sortType: "new" }),
+      useFeed({ communities: toCommunities(communityAddresses), sortType: "new" }),
     );
     const waitFor = testUtils.createWaitFor(rendered, { timeout });
 

--- a/test/browser-pkc-js-mock/communities.test.js
+++ b/test/browser-pkc-js-mock/communities.test.js
@@ -8,6 +8,7 @@ import PkcJsMock from "../../dist/lib/pkc-js/pkc-js-mock";
 setPkcJs(PkcJsMock);
 
 const timeout = 10000;
+const toCommunity = (name) => (name ? { name } : undefined);
 
 describe("communities (pkc-js mock)", () => {
   beforeAll(async () => {
@@ -25,7 +26,9 @@ describe("communities (pkc-js mock)", () => {
   describe("no communities in database", () => {
     it("get communities one at a time", async () => {
       console.log("starting communities tests");
-      const rendered = renderHook((communityAddress) => useCommunity({ communityAddress }));
+      const rendered = renderHook((communityAddress) =>
+        useCommunity({ community: toCommunity(communityAddress) }),
+      );
       const waitFor = testUtils.createWaitFor(rendered, { timeout });
 
       expect(rendered.result.current?.updatedAt).to.equal(undefined);

--- a/test/browser-pkc-js-mock/feeds.test.js
+++ b/test/browser-pkc-js-mock/feeds.test.js
@@ -8,6 +8,7 @@ setPkcJs(PkcJsMock);
 import testUtils from "../../dist/lib/test-utils";
 
 const timeout = 10000;
+const toCommunities = (names) => names?.map((name) => ({ name }));
 
 describe("feeds (pkc-js mock)", () => {
   beforeAll(async () => {
@@ -50,7 +51,7 @@ describe("feeds (pkc-js mock)", () => {
 
     it("get feed page 1 with 1 community sorted by default (hot)", async () => {
       // get feed with 1 sub
-      rendered.rerender({ communityAddresses: ["community address 1"] });
+      rendered.rerender({ communities: toCommunities(["community address 1"]) });
       // initial state
       expect(typeof rendered.result.current.hasMore).to.equal("boolean");
       expect(typeof rendered.result.current.loadMore).to.equal("function");
@@ -70,14 +71,14 @@ describe("feeds (pkc-js mock)", () => {
     });
 
     it("change community addresses and sort type", async () => {
-      rendered.rerender({ communityAddresses: ["community address 1"], sortType: "hot" });
+      rendered.rerender({ communities: toCommunities(["community address 1"]), sortType: "hot" });
       await waitFor(() => !!rendered.result.current.feed[0].cid.match(/community address 1/));
       expect(rendered.result.current.feed[0].cid).to.match(/community address 1/);
       expect(rendered.result.current.feed.length).to.equal(postsPerPage);
 
       // change community addresses
       rendered.rerender({
-        communityAddresses: ["community address 2", "community address 3"],
+        communities: toCommunities(["community address 2", "community address 3"]),
         sortType: "hot",
       });
       await waitFor(() => !!rendered.result.current.feed[0].cid.match(/community address (2|3)/));
@@ -88,7 +89,7 @@ describe("feeds (pkc-js mock)", () => {
 
       // change sort type
       rendered.rerender({
-        communityAddresses: ["community address 2", "community address 3"],
+        communities: toCommunities(["community address 2", "community address 3"]),
         sortType: "new",
       });
       await waitFor(() => !!rendered.result.current.feed[0].cid.match(/community address (2|3)/));
@@ -99,7 +100,7 @@ describe("feeds (pkc-js mock)", () => {
 
       // change community addresses and sort type
       rendered.rerender({
-        communityAddresses: ["community address 4", "community address 5"],
+        communities: toCommunities(["community address 4", "community address 5"]),
         sortType: "topAll",
       });
       await waitFor(() => !!rendered.result.current.feed[0].cid.match(/community address (4|5)/));
@@ -109,7 +110,7 @@ describe("feeds (pkc-js mock)", () => {
 
     it("get feed with 1 community and scroll to multiple pages", async () => {
       // get feed with 1 sub
-      rendered.rerender({ communityAddresses: ["community address 1"] });
+      rendered.rerender({ communities: toCommunities(["community address 1"]) });
       // wait for posts to be added, should get full first page
       await waitFor(() => rendered.result.current.feed.length > 0);
 
@@ -131,7 +132,7 @@ describe("feeds (pkc-js mock)", () => {
       while (communityAddresses.length < 25) {
         communityAddresses.push(`community address ${communityAddresses.length + 1}`);
       }
-      rendered.rerender({ communityAddresses });
+      rendered.rerender({ communities: toCommunities(communityAddresses) });
       // wait for posts to be added, should get full first page
       await waitFor(() => rendered.result.current.feed.length > 0);
 

--- a/test/test-server/config.js
+++ b/test/test-server/config.js
@@ -1,5 +1,21 @@
-const getPort = (envName, fallback) => {
-  const value = process.env[envName];
+const getEnvValue = (envNames) => {
+  for (const envName of envNames) {
+    const nodeValue = typeof process !== "undefined" ? process.env?.[envName] : undefined;
+    if (nodeValue) {
+      return nodeValue;
+    }
+
+    const browserValue = import.meta.env?.[envName];
+    if (browserValue) {
+      return browserValue;
+    }
+  }
+
+  return undefined;
+};
+
+const getPort = (envNames, fallback) => {
+  const value = getEnvValue(envNames);
   if (!value) {
     return fallback;
   }
@@ -26,5 +42,5 @@ export const pubsubIpfs = {
 };
 
 export const pkcRpc = {
-  port: getPort("TEST_PKC_RPC_PORT", 48392),
+  port: getPort(["TEST_PKC_RPC_PORT", "VITE_TEST_PKC_RPC_PORT"], 48392),
 };

--- a/test/test-server/config.js
+++ b/test/test-server/config.js
@@ -1,3 +1,16 @@
+const getPort = (envName, fallback) => {
+  const value = process.env[envName];
+  if (!value) {
+    return fallback;
+  }
+
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed <= 0) {
+    throw Error(`${envName} '${value}' not a valid port`);
+  }
+  return parsed;
+};
+
 export const offlineIpfs = {
   apiPort: 14325,
   gatewayPort: 14326,
@@ -13,5 +26,5 @@ export const pubsubIpfs = {
 };
 
 export const pkcRpc = {
-  port: 48392,
+  port: getPort("TEST_PKC_RPC_PORT", 48392),
 };


### PR DESCRIPTION
## Summary
- make community-fetching hooks accept only explicit `community` / `communities` objects
- reject removed `communityAddress`, `communityAddresses`, and `communityRefs` inputs at runtime
- preserve the public-key-first `pkc-js` path when `{ name, publicKey }` is provided, while keeping name-only lookups on the legacy address path
- update README examples and hook tests for the breaking API

## Verification
- `yarn build`
- `NODE_OPTIONS=--max-old-space-size=8192 yarn test`
- `yarn prettier`

## Notes
- `node scripts/verify-hooks-stores-coverage.mjs` still fails because the repo-wide hooks/stores baseline is already below the enforced 100% threshold in unrelated files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it’s a breaking API change for multiple hooks (`useCommunity`/`useCommunities`/`useFeed`/`useCommunitiesStates`) and refactors feed/community keying to use `publicKey`-derived keys, which can affect caching and store lookups.
> 
> **Overview**
> **Breaking hook API change:** community-fetching hooks now require explicit `community`/`communities` objects (e.g. `{name, publicKey}`) and runtime-reject legacy inputs (`communityAddress`, `communityAddresses`, `communityRefs`). Feeds/states outputs also rename `communityAddressesWithNewerPosts` to `communityKeysWithNewerPosts`.
> 
> **Refactor to stable community keys:** adds `lib/community-ref` utilities and updates community + feed stores to key/cache by a derived community key (preferring `publicKey`), pass structured lookup options into `pkc` calls, and ensure `resetFeed`/refresh paths use the original community refs.
> 
> **Tests/docs/CI:** updates README examples and hook/store tests to the new shapes (including publicKey-keyed cases), and hardens CI coverage runs by increasing Node memory, making Vitest coverage more stable (single worker), and accepting a known Vitest worker-teardown OOM false-negative via a new helper script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c281207381bc07fbe2ccd416a705444323e69ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated API docs and examples to use object-based community identifiers (name/publicKey) and reflect the renamed feed result field.

* **Refactor**
  * Hooks, stores, and feed logic now operate on community identifier objects and stable community keys instead of plain address strings.

* **Types / API**
  * Added a CommunityIdentifier type and renamed feed output to communityKeysWithNewerPosts; hook options now accept community objects.

* **Tests**
  * Test suites updated to the new input shapes and added coverage for keying/publicKey cases.

* **Chores**
  * CI/test runner handling improved with a helper script to accept known worker errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->