### PR TITLE
fix(build): remove consumer patch requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ yarn add https://github.com/bitsocialnet/bitsocial-react-hooks.git#<commit-hash>
 ```
 
 Use a pinned commit hash (or tag) so installs are reproducible.
+The published build is self-contained ESM, so consumers should not need postinstall import-rewrite patches.
 
 ## Development Setup
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "typings": "dist/index.d.ts",
   "scripts": {
     "prebuild": "rm -rf dist",
-    "build": "node ./node_modules/typescript/bin/tsc --project config/tsconfig.json",
+    "build": "node ./node_modules/typescript/bin/tsc --project config/tsconfig.json && node scripts/normalize-dist-esm.mjs && node scripts/verify-dist-esm.mjs",
     "build:watch": "node ./node_modules/typescript/bin/tsc --project config/tsconfig.json --watch",
     "knip": "knip --production --include dependencies,unlisted,binaries --no-progress",
     "knip:full": "knip --no-progress --no-exit-code",

--- a/scripts/dist-esm-utils.mjs
+++ b/scripts/dist-esm-utils.mjs
@@ -1,0 +1,142 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const repoRoot = path.resolve(import.meta.dirname, "..");
+export const distRoot = path.join(repoRoot, "dist");
+
+const staticImportPattern = /(from\s+|import\s+)(['"])(\.\.?\/[^'"]+)\2/g;
+const dynamicImportPattern = /\bimport\(\s*(['"])(\.\.?\/[^'"]+)\1\s*\)/g;
+
+const splitSpecifier = (specifier) => {
+  const suffixStart = specifier.search(/[?#]/);
+
+  if (suffixStart === -1) {
+    return { bareSpecifier: specifier, suffix: "" };
+  }
+
+  return {
+    bareSpecifier: specifier.slice(0, suffixStart),
+    suffix: specifier.slice(suffixStart),
+  };
+};
+
+const resolveRelativeSpecifier = (filePath, specifier) => {
+  const { bareSpecifier, suffix } = splitSpecifier(specifier);
+
+  if (path.extname(bareSpecifier)) {
+    return null;
+  }
+
+  const absoluteSpecifierPath = path.resolve(path.dirname(filePath), bareSpecifier);
+
+  if (fs.existsSync(`${absoluteSpecifierPath}.js`)) {
+    return `${bareSpecifier}.js${suffix}`;
+  }
+
+  if (fs.existsSync(path.join(absoluteSpecifierPath, "index.js"))) {
+    return `${bareSpecifier}/index.js${suffix}`;
+  }
+
+  return null;
+};
+
+const relativeSpecifierExists = (filePath, specifier) => {
+  const { bareSpecifier } = splitSpecifier(specifier);
+  const absoluteSpecifierPath = path.resolve(path.dirname(filePath), bareSpecifier);
+
+  if (path.extname(bareSpecifier)) {
+    return fs.existsSync(absoluteSpecifierPath);
+  }
+
+  return (
+    fs.existsSync(`${absoluteSpecifierPath}.js`) ||
+    fs.existsSync(path.join(absoluteSpecifierPath, "index.js"))
+  );
+};
+
+export const listDistModuleFiles = () => {
+  const files = [];
+  const stack = [distRoot];
+
+  while (stack.length) {
+    const currentPath = stack.pop();
+    if (!currentPath || !fs.existsSync(currentPath)) {
+      continue;
+    }
+
+    for (const entry of fs.readdirSync(currentPath, { withFileTypes: true })) {
+      const entryPath = path.join(currentPath, entry.name);
+
+      if (entry.isDirectory()) {
+        stack.push(entryPath);
+        continue;
+      }
+
+      if (
+        entry.isFile() &&
+        (entry.name.endsWith(".js") || entry.name.endsWith(".d.ts"))
+      ) {
+        files.push(entryPath);
+      }
+    }
+  }
+
+  return files.sort();
+};
+
+export const normalizeRelativeSpecifiers = (source, filePath) => {
+  let rewriteCount = 0;
+
+  const replaceStaticSpecifier = (match, prefix, quote, specifier) => {
+    const resolvedSpecifier = resolveRelativeSpecifier(filePath, specifier);
+
+    if (!resolvedSpecifier || resolvedSpecifier === specifier) {
+      return match;
+    }
+
+    rewriteCount += 1;
+    return `${prefix}${quote}${resolvedSpecifier}${quote}`;
+  };
+
+  const replaceDynamicSpecifier = (match, quote, specifier) => {
+    const resolvedSpecifier = resolveRelativeSpecifier(filePath, specifier);
+
+    if (!resolvedSpecifier || resolvedSpecifier === specifier) {
+      return match;
+    }
+
+    rewriteCount += 1;
+    return `import(${quote}${resolvedSpecifier}${quote})`;
+  };
+
+  const updatedSource = source
+    .replace(staticImportPattern, replaceStaticSpecifier)
+    .replace(dynamicImportPattern, replaceDynamicSpecifier);
+
+  return { updatedSource, rewriteCount };
+};
+
+export const findInvalidRelativeSpecifiers = (source, filePath) => {
+  const issues = [];
+  const collect = (specifier) => {
+    if (!relativeSpecifierExists(filePath, specifier)) {
+      issues.push(specifier);
+    }
+  };
+
+  const collectStatic = (match, prefix, quote, specifier) => {
+    collect(specifier);
+    return match;
+  };
+
+  const collectDynamic = (match, quote, specifier) => {
+    collect(specifier);
+    return match;
+  };
+
+  source
+    .replace(staticImportPattern, collectStatic)
+    .replace(dynamicImportPattern, collectDynamic);
+
+  return issues;
+};

--- a/scripts/normalize-dist-esm.mjs
+++ b/scripts/normalize-dist-esm.mjs
@@ -1,0 +1,34 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { distRoot, listDistModuleFiles, normalizeRelativeSpecifiers } from "./dist-esm-utils.mjs";
+
+if (!fs.existsSync(distRoot)) {
+  console.error("[normalize-dist-esm] dist/ not found. Run the TypeScript build first.");
+  process.exit(1);
+}
+
+let touchedFiles = 0;
+let rewrittenImports = 0;
+
+for (const filePath of listDistModuleFiles()) {
+  const source = fs.readFileSync(filePath, "utf8");
+  const { updatedSource, rewriteCount } = normalizeRelativeSpecifiers(source, filePath);
+
+  if (!rewriteCount || updatedSource === source) {
+    continue;
+  }
+
+  fs.writeFileSync(filePath, updatedSource, "utf8");
+  touchedFiles += 1;
+  rewrittenImports += rewriteCount;
+}
+
+const summary = `[normalize-dist-esm] Rewrote ${rewrittenImports} relative imports across ${touchedFiles} files.`;
+console.log(summary);
+
+if (!rewrittenImports) {
+  console.warn(
+    "[normalize-dist-esm] No dist imports needed rewriting. Verify the build output still matches package expectations.",
+  );
+}

--- a/scripts/verify-dist-esm.mjs
+++ b/scripts/verify-dist-esm.mjs
@@ -22,7 +22,9 @@ for (const filePath of listDistModuleFiles()) {
 }
 
 const packageEntryPath = path.join(distRoot, "index.js");
-if (fs.existsSync(packageEntryPath)) {
+if (!fs.existsSync(packageEntryPath)) {
+  failures.push("index.js is missing from dist/ (package main entry).");
+} else {
   const packageEntry = fs.readFileSync(packageEntryPath, "utf8");
 
   if (

--- a/scripts/verify-dist-esm.mjs
+++ b/scripts/verify-dist-esm.mjs
@@ -1,0 +1,45 @@
+import fs from "node:fs";
+import path from "node:path";
+
+import { distRoot, findInvalidRelativeSpecifiers, listDistModuleFiles } from "./dist-esm-utils.mjs";
+
+if (!fs.existsSync(distRoot)) {
+  console.error("[verify-dist-esm] dist/ not found. Run the TypeScript build first.");
+  process.exit(1);
+}
+
+const failures = [];
+
+for (const filePath of listDistModuleFiles()) {
+  const source = fs.readFileSync(filePath, "utf8");
+  const invalidSpecifiers = findInvalidRelativeSpecifiers(source, filePath);
+
+  if (invalidSpecifiers.length) {
+    failures.push(
+      `${path.relative(distRoot, filePath)} has unresolved relative imports: ${invalidSpecifiers.join(", ")}`,
+    );
+  }
+}
+
+const packageEntryPath = path.join(distRoot, "index.js");
+if (fs.existsSync(packageEntryPath)) {
+  const packageEntry = fs.readFileSync(packageEntryPath, "utf8");
+
+  if (
+    packageEntry.includes('require("util")') ||
+    packageEntry.includes("DEBUG_DEPTH") ||
+    packageEntry.includes("DEBUG_ARRAY")
+  ) {
+    failures.push("index.js still contains the Node-only util debug patch.");
+  }
+}
+
+if (failures.length) {
+  console.error("[verify-dist-esm] Build output is not publishable:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("[verify-dist-esm] dist ESM output verified.");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,6 @@
 import polyfill from "./lib/polyfill";
 polyfill();
 
-// fix DEBUG_DEPTH bug https://github.com/debug-js/debug/issues/746
-try {
-  if (process.env.DEBUG_DEPTH) {
-    require("util").inspect.defaultOptions.depth = process.env.DEBUG_DEPTH;
-  }
-  if (process.env.DEBUG_ARRAY) {
-    require("util").inspect.defaultOptions.maxArrayLength = process.env.DEBUG_ARRAY;
-  }
-} catch (e) {}
-
 // accounts
 import {
   useAccount,

--- a/src/stores/communities-pages/communities-pages-store.test.ts
+++ b/src/stores/communities-pages/communities-pages-store.test.ts
@@ -423,6 +423,18 @@ describe("communities pages store", () => {
     expect(getCommunityFirstPageCid(community as any, "hot")).toBe("default-posts-page-cid");
   });
 
+  test("getCommunityFirstPageCid accepts strict community refs without address", () => {
+    const community = {
+      name: "news.eth",
+      publicKey: "12D3KooWNews",
+      posts: {
+        pageCids: { hot: "strict-ref-page-cid" },
+      },
+    };
+
+    expect(getCommunityFirstPageCid(community as any, "hot")).toBe("strict-ref-page-cid");
+  });
+
   test("fetchPage returns cached page when in database", async () => {
     const mockCommunity = await mockAccount.pkc.createCommunity({
       address: "community address 1",

--- a/src/stores/communities-pages/communities-pages-store.ts
+++ b/src/stores/communities-pages/communities-pages-store.ts
@@ -407,7 +407,10 @@ export const getCommunityFirstPageCid = (
   sortType: string,
   pageType = "posts",
 ) => {
-  assert(community?.address, `getCommunityFirstPageCid community '${community}' invalid`);
+  assert(
+    community && typeof community === "object",
+    `getCommunityFirstPageCid community '${community}' invalid`,
+  );
   assert(
     sortType && typeof sortType === "string",
     `getCommunityFirstPageCid sortType '${sortType}' invalid`,


### PR DESCRIPTION
## Summary
- remove the browser-incompatible `require("util")` debug shim from the public entry
- make the package build own ESM specifier normalization/verification so downstream apps do not need postinstall patch scripts
- allow `getCommunityFirstPageCid` to work with strict `{ name, publicKey }` community refs that do not carry a legacy `address`
- document the self-contained ESM expectation in the README

## Verification
- `yarn install`
- `yarn build`
- `NODE_OPTIONS=--max-old-space-size=8192 node ./node_modules/vitest/vitest.mjs run --config config/vitest.config.js stores/communities-pages/communities-pages-store.test.ts`

## Verification Blockers
- `yarn test` reached `998` passing tests and then hit a repo-level Vitest worker OOM under Node 22 before the run could exit cleanly.
- Full coverage verification is also blocked by repo-wide Vitest coverage instability: the default coverage run OOMs workers, and an isolated coverage attempt never completed `hooks/accounts/accounts.test.ts`, which leaves the hooks/stores coverage summary incomplete.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the published build output and adds post-build rewriting/verification steps that could affect module resolution for consumers if the rewrite logic is incorrect.
> 
> **Overview**
> **Removes consumer-side ESM patching needs** by dropping the Node-only `require("util")` debug shim from `src/index.ts` and documenting that the published package is self-contained ESM.
> 
> **Hardens the build pipeline** by extending `yarn build` to post-process `dist/` output: new scripts normalize relative import specifiers to include `.js`/`index.js` where needed and then verify there are no unresolved relative imports (and that `dist/index.js` exists and stays free of the removed shim).
> 
> **Loosens community page CID lookup** by updating `getCommunityFirstPageCid` to validate only that `community` is an object (not that it has an `address`), with a new test covering strict `{name, publicKey}` community refs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c42bb8c0278d47c301a177c024522b258b501b3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README clarifying that the published ESM build is fully self-contained and requires no additional post-installation patches or rewrites.

* **Bug Fixes**
  * Improved input validation for community page operations to better handle various community reference object formats.

* **Chores**
  * Strengthened build pipeline with automated normalization and verification steps to ensure reliable ESM build output quality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->