### PR TITLE
fix(communities): unwrap stats cid content

### DIFF
--- a/src/hooks/communities.test.ts
+++ b/src/hooks/communities.test.ts
@@ -645,6 +645,23 @@ describe("communities", () => {
     }
   });
 
+  test("useCommunityStats keeps unrecognized content responses", async () => {
+    let fetchSpy: { mockRestore: () => void } | undefined;
+    try {
+      fetchSpy = vi.spyOn(PKC.prototype as any, "fetchCid").mockResolvedValue({
+        content: "not json stats content",
+      });
+      const rendered = renderHook<any, any>(() =>
+        useCommunityStats({ community: { name: "unknown content stats" } }),
+      );
+      const waitFor = testUtils.createWaitFor(rendered);
+      await waitFor(() => rendered.result.current.state === "succeeded");
+      expect(rendered.result.current.content).toBe("not json stats content");
+    } finally {
+      fetchSpy?.mockRestore();
+    }
+  });
+
   test("useCommunityStats fetchCid error logs (stmt 110)", async () => {
     const origFetch = PKC.prototype.fetchCid;
     (PKC.prototype as any).fetchCid = () => Promise.reject(new Error("fetchCid failed"));

--- a/src/hooks/communities.test.ts
+++ b/src/hooks/communities.test.ts
@@ -532,6 +532,76 @@ describe("communities", () => {
     expect(rendered.result.current.hourActiveUserCount).toBe(1);
   });
 
+  test("useCommunityStats unwraps fetchCid content responses", async () => {
+    const origFetch = PKC.prototype.fetchCid;
+    (PKC.prototype as any).fetchCid = () =>
+      Promise.resolve({
+        content: {
+          hourActiveUserCount: 3,
+          weekActiveUserCount: 33,
+          allPostCount: 333,
+        },
+      });
+    const rendered = renderHook<any, any>(() =>
+      useCommunityStats({ community: { name: "wrapped stats" } }),
+    );
+    const waitFor = testUtils.createWaitFor(rendered);
+    try {
+      await waitFor(() => rendered.result.current.state === "succeeded");
+      expect(rendered.result.current.hourActiveUserCount).toBe(3);
+      expect(rendered.result.current.weekActiveUserCount).toBe(33);
+      expect(rendered.result.current.allPostCount).toBe(333);
+    } finally {
+      (PKC.prototype as any).fetchCid = origFetch;
+    }
+  });
+
+  test("useCommunityStats parses string fetchCid content responses", async () => {
+    const origFetch = PKC.prototype.fetchCid;
+    (PKC.prototype as any).fetchCid = () =>
+      Promise.resolve({
+        content: JSON.stringify({
+          hourActiveUserCount: 4,
+          weekActiveUserCount: 44,
+          allPostCount: 444,
+        }),
+      });
+    const rendered = renderHook<any, any>(() =>
+      useCommunityStats({ community: { name: "string wrapped stats" } }),
+    );
+    const waitFor = testUtils.createWaitFor(rendered);
+    try {
+      await waitFor(() => rendered.result.current.state === "succeeded");
+      expect(rendered.result.current.hourActiveUserCount).toBe(4);
+      expect(rendered.result.current.weekActiveUserCount).toBe(44);
+      expect(rendered.result.current.allPostCount).toBe(444);
+    } finally {
+      (PKC.prototype as any).fetchCid = origFetch;
+    }
+  });
+
+  test("useCommunityStats accepts object fetchCid responses", async () => {
+    const origFetch = PKC.prototype.fetchCid;
+    (PKC.prototype as any).fetchCid = () =>
+      Promise.resolve({
+        hourActiveUserCount: 5,
+        weekActiveUserCount: 55,
+        allPostCount: 555,
+      });
+    const rendered = renderHook<any, any>(() =>
+      useCommunityStats({ community: { name: "object stats" } }),
+    );
+    const waitFor = testUtils.createWaitFor(rendered);
+    try {
+      await waitFor(() => rendered.result.current.state === "succeeded");
+      expect(rendered.result.current.hourActiveUserCount).toBe(5);
+      expect(rendered.result.current.weekActiveUserCount).toBe(55);
+      expect(rendered.result.current.allPostCount).toBe(555);
+    } finally {
+      (PKC.prototype as any).fetchCid = origFetch;
+    }
+  });
+
   test("useCommunityStats fetchCid error logs (stmt 110)", async () => {
     const origFetch = PKC.prototype.fetchCid;
     (PKC.prototype as any).fetchCid = () => Promise.reject(new Error("fetchCid failed"));

--- a/src/hooks/communities.test.ts
+++ b/src/hooks/communities.test.ts
@@ -533,72 +533,115 @@ describe("communities", () => {
   });
 
   test("useCommunityStats unwraps fetchCid content responses", async () => {
-    const origFetch = PKC.prototype.fetchCid;
-    (PKC.prototype as any).fetchCid = () =>
-      Promise.resolve({
+    let fetchSpy: { mockRestore: () => void } | undefined;
+    try {
+      fetchSpy = vi.spyOn(PKC.prototype as any, "fetchCid").mockResolvedValue({
         content: {
           hourActiveUserCount: 3,
           weekActiveUserCount: 33,
           allPostCount: 333,
         },
       });
-    const rendered = renderHook<any, any>(() =>
-      useCommunityStats({ community: { name: "wrapped stats" } }),
-    );
-    const waitFor = testUtils.createWaitFor(rendered);
-    try {
+      const rendered = renderHook<any, any>(() =>
+        useCommunityStats({ community: { name: "wrapped stats" } }),
+      );
+      const waitFor = testUtils.createWaitFor(rendered);
       await waitFor(() => rendered.result.current.state === "succeeded");
       expect(rendered.result.current.hourActiveUserCount).toBe(3);
       expect(rendered.result.current.weekActiveUserCount).toBe(33);
       expect(rendered.result.current.allPostCount).toBe(333);
     } finally {
-      (PKC.prototype as any).fetchCid = origFetch;
+      fetchSpy?.mockRestore();
     }
   });
 
   test("useCommunityStats parses string fetchCid content responses", async () => {
-    const origFetch = PKC.prototype.fetchCid;
-    (PKC.prototype as any).fetchCid = () =>
-      Promise.resolve({
+    let fetchSpy: { mockRestore: () => void } | undefined;
+    try {
+      fetchSpy = vi.spyOn(PKC.prototype as any, "fetchCid").mockResolvedValue({
         content: JSON.stringify({
           hourActiveUserCount: 4,
           weekActiveUserCount: 44,
           allPostCount: 444,
         }),
       });
-    const rendered = renderHook<any, any>(() =>
-      useCommunityStats({ community: { name: "string wrapped stats" } }),
-    );
-    const waitFor = testUtils.createWaitFor(rendered);
-    try {
+      const rendered = renderHook<any, any>(() =>
+        useCommunityStats({ community: { name: "string wrapped stats" } }),
+      );
+      const waitFor = testUtils.createWaitFor(rendered);
       await waitFor(() => rendered.result.current.state === "succeeded");
       expect(rendered.result.current.hourActiveUserCount).toBe(4);
       expect(rendered.result.current.weekActiveUserCount).toBe(44);
       expect(rendered.result.current.allPostCount).toBe(444);
     } finally {
-      (PKC.prototype as any).fetchCid = origFetch;
+      fetchSpy?.mockRestore();
     }
   });
 
-  test("useCommunityStats accepts object fetchCid responses", async () => {
-    const origFetch = PKC.prototype.fetchCid;
-    (PKC.prototype as any).fetchCid = () =>
-      Promise.resolve({
-        hourActiveUserCount: 5,
-        weekActiveUserCount: 55,
-        allPostCount: 555,
-      });
-    const rendered = renderHook<any, any>(() =>
-      useCommunityStats({ community: { name: "object stats" } }),
-    );
-    const waitFor = testUtils.createWaitFor(rendered);
+  test("useCommunityStats parses string fetchCid responses", async () => {
+    let fetchSpy: { mockRestore: () => void } | undefined;
     try {
+      fetchSpy = vi.spyOn(PKC.prototype as any, "fetchCid").mockResolvedValue(
+        JSON.stringify({
+          hourActiveUserCount: 5,
+          weekActiveUserCount: 55,
+          allPostCount: 555,
+        }),
+      );
+      const rendered = renderHook<any, any>(() =>
+        useCommunityStats({ community: { name: "string stats" } }),
+      );
+      const waitFor = testUtils.createWaitFor(rendered);
       await waitFor(() => rendered.result.current.state === "succeeded");
       expect(rendered.result.current.hourActiveUserCount).toBe(5);
       expect(rendered.result.current.weekActiveUserCount).toBe(55);
       expect(rendered.result.current.allPostCount).toBe(555);
     } finally {
-      (PKC.prototype as any).fetchCid = origFetch;
+      fetchSpy?.mockRestore();
+    }
+  });
+
+  test("useCommunityStats accepts object fetchCid responses", async () => {
+    let fetchSpy: { mockRestore: () => void } | undefined;
+    try {
+      fetchSpy = vi.spyOn(PKC.prototype as any, "fetchCid").mockResolvedValue({
+        hourActiveUserCount: 6,
+        weekActiveUserCount: 66,
+        allPostCount: 666,
+      });
+      const rendered = renderHook<any, any>(() =>
+        useCommunityStats({ community: { name: "object stats" } }),
+      );
+      const waitFor = testUtils.createWaitFor(rendered);
+      await waitFor(() => rendered.result.current.state === "succeeded");
+      expect(rendered.result.current.hourActiveUserCount).toBe(6);
+      expect(rendered.result.current.weekActiveUserCount).toBe(66);
+      expect(rendered.result.current.allPostCount).toBe(666);
+    } finally {
+      fetchSpy?.mockRestore();
+    }
+  });
+
+  test("useCommunityStats keeps direct stats responses with content fields", async () => {
+    let fetchSpy: { mockRestore: () => void } | undefined;
+    try {
+      fetchSpy = vi.spyOn(PKC.prototype as any, "fetchCid").mockResolvedValue({
+        content: "not json stats content",
+        hourActiveUserCount: 5,
+        weekActiveUserCount: 55,
+        allPostCount: 555,
+      });
+      const rendered = renderHook<any, any>(() =>
+        useCommunityStats({ community: { name: "stats with content" } }),
+      );
+      const waitFor = testUtils.createWaitFor(rendered);
+      await waitFor(() => rendered.result.current.state === "succeeded");
+      expect(rendered.result.current.hourActiveUserCount).toBe(5);
+      expect(rendered.result.current.weekActiveUserCount).toBe(55);
+      expect(rendered.result.current.allPostCount).toBe(555);
+      expect(rendered.result.current.content).toBe("not json stats content");
+    } finally {
+      fetchSpy?.mockRestore();
     }
   });
 

--- a/src/hooks/communities.ts
+++ b/src/hooks/communities.ts
@@ -26,6 +26,16 @@ import shallow from "zustand/shallow";
 import { getChainProviders, getPkcCommunityAddresses } from "../lib/pkc-compat";
 import { getCommunityRefKey, getUniqueSortedCommunityRefs } from "../lib/community-ref";
 
+const parseMaybeJson = (value: unknown) => (typeof value === "string" ? JSON.parse(value) : value);
+
+const parseFetchedCommunityStats = (fetchedCid: unknown): CommunityStats => {
+  const parsedCid = parseMaybeJson(fetchedCid);
+  if (parsedCid && typeof parsedCid === "object" && "content" in parsedCid) {
+    return parseMaybeJson((parsedCid as { content: unknown }).content) as CommunityStats;
+  }
+  return parsedCid as CommunityStats;
+};
+
 /**
  * @param community - The community identifier, e.g. {name: 'memes.eth'} or {publicKey: '12D3KooW...'}
  * @param acountName - The nickname of the account, e.g. 'Account 1'. If no accountName is provided, use
@@ -183,7 +193,7 @@ export function useCommunityStats(options?: UseCommunityStatsOptions): UseCommun
       let fetchedCid;
       try {
         fetchedCid = await account.pkc.fetchCid({ cid: communityStatsCid });
-        fetchedCid = JSON.parse(fetchedCid);
+        fetchedCid = parseFetchedCommunityStats(fetchedCid);
         if (cancelled) {
           return;
         }

--- a/src/hooks/communities.ts
+++ b/src/hooks/communities.ts
@@ -28,6 +28,14 @@ import { getCommunityRefKey, getUniqueSortedCommunityRefs } from "../lib/communi
 
 const parseMaybeJson = (value: unknown) => (typeof value === "string" ? JSON.parse(value) : value);
 
+const tryParseMaybeJson = (value: unknown) => {
+  try {
+    return parseMaybeJson(value);
+  } catch {
+    return value;
+  }
+};
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   !!value && typeof value === "object";
 
@@ -41,7 +49,7 @@ const parseFetchedCommunityStats = (fetchedCid: unknown): CommunityStats => {
     return parsedCid;
   }
   if (isRecord(parsedCid) && "content" in parsedCid) {
-    const parsedContent = parseMaybeJson(parsedCid.content);
+    const parsedContent = tryParseMaybeJson(parsedCid.content);
     if (isCommunityStatsPayload(parsedContent)) {
       return parsedContent;
     }

--- a/src/hooks/communities.ts
+++ b/src/hooks/communities.ts
@@ -28,10 +28,23 @@ import { getCommunityRefKey, getUniqueSortedCommunityRefs } from "../lib/communi
 
 const parseMaybeJson = (value: unknown) => (typeof value === "string" ? JSON.parse(value) : value);
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  !!value && typeof value === "object";
+
+const isCommunityStatsPayload = (value: unknown): value is CommunityStats =>
+  isRecord(value) &&
+  ("hourActiveUserCount" in value || "weekActiveUserCount" in value || "allPostCount" in value);
+
 const parseFetchedCommunityStats = (fetchedCid: unknown): CommunityStats => {
   const parsedCid = parseMaybeJson(fetchedCid);
-  if (parsedCid && typeof parsedCid === "object" && "content" in parsedCid) {
-    return parseMaybeJson((parsedCid as { content: unknown }).content) as CommunityStats;
+  if (isCommunityStatsPayload(parsedCid)) {
+    return parsedCid;
+  }
+  if (isRecord(parsedCid) && "content" in parsedCid) {
+    const parsedContent = parseMaybeJson(parsedCid.content);
+    if (isCommunityStatsPayload(parsedContent)) {
+      return parsedContent;
+    }
   }
   return parsedCid as CommunityStats;
 };


### PR DESCRIPTION
## Summary
- unwrap `fetchCid` stats responses that now return an object with `content`
- preserve support for legacy raw JSON strings and plain object stats payloads
- add regression tests for wrapped object content, wrapped string content, and direct object payloads

## Verification
- `corepack yarn prettier`
- `corepack yarn test src/hooks/communities.test.ts`
- `corepack yarn build`
- `corepack yarn lint` (passes with existing warnings)
- `corepack yarn type-check`
- `corepack yarn test:coverage:hooks-stores` failed twice from Node/Vitest worker heap exhaustion after running the suite; retry with a single forked worker still ended with OOM after 35/36 files and 1011/1047 tests passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `useCommunityStats` parses `pkc.fetchCid` responses, which could surface new runtime parsing behavior (e.g., unexpected non-JSON strings) but is limited to stats fetching logic and is well-covered by new tests.
> 
> **Overview**
> `useCommunityStats` now normalizes community stats returned by `pkc.fetchCid`, handling both legacy raw JSON strings/direct objects and newer responses that wrap stats under a `content` field (including `content` as a JSON string). 
> 
> Adds regression tests covering wrapped object stats, wrapped string stats, raw string responses, direct object payloads, and ensuring unknown/extra `content` is preserved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0bf5cbb2150773c7cb60451f10d2dbecc90b0e79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added tests ensuring community statistics are correctly handled across multiple response formats.

* **Bug Fixes**
  * Improved runtime parsing and normalization of community statistics so varied payload shapes (including JSON strings, nested/wrapped objects, and direct fields) are handled consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->