### PR TITLE
[codex] Add npm trusted publishing for react hooks

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -135,10 +135,15 @@ jobs:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     permissions:
       contents: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.ref_name }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.14.0'
+          registry-url: 'https://registry.npmjs.org'
       - name: Download dist artifact
         uses: actions/download-artifact@v4
         with:
@@ -152,8 +157,27 @@ jobs:
       - run: git add dist badges/coverage.json --force
       - run: git status
       - uses: stefanzweifel/git-auto-commit-action@v4
+        id: dist_commit
         with:
           commit_message: 'chore(ci): update dist and coverage badge'
           file_pattern: 'dist badges/coverage.json'
           add_options: '--force'
           branch: ${{ github.ref_name }}
+      - name: Upgrade npm for trusted publishing
+        if: steps.dist_commit.outputs.changes_detected == 'true'
+        run: npm install -g npm@11
+      - name: Check if package version already exists
+        if: steps.dist_commit.outputs.changes_detected == 'true'
+        id: check_npm_version
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          if npm view @bitsocial/bitsocial-react-hooks@$PACKAGE_VERSION version 2>/dev/null; then
+            echo "Version $PACKAGE_VERSION already exists on npm, skipping publish"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Version $PACKAGE_VERSION not found on npm, will publish"
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Publish to npm
+        if: steps.dist_commit.outputs.changes_detected == 'true' && steps.check_npm_version.outputs.exists == 'false'
+        run: npm publish --access public --provenance

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -169,6 +169,8 @@ jobs:
       - name: Check if package version already exists
         if: steps.dist_commit.outputs.changes_detected == 'true'
         id: check_npm_version
+        env:
+          NODE_AUTH_TOKEN: ''
         run: |
           PACKAGE_VERSION=$(node -p "require('./package.json').version")
           if npm view @bitsocial/bitsocial-react-hooks@$PACKAGE_VERSION version 2>/dev/null; then
@@ -180,4 +182,6 @@ jobs:
           fi
       - name: Publish to npm
         if: steps.dist_commit.outputs.changes_detected == 'true' && steps.check_npm_version.outputs.exists == 'false'
+        env:
+          NODE_AUTH_TOKEN: ''
         run: npm publish --access public --provenance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Only record items that are repo-specific, likely to recur, and have a concrete m
 
 ## Project Overview
 
-bitsocial-react-hooks (`@bitsocialnet/bitsocial-react-hooks`) is a React hooks library for the Bitsocial protocol. It provides React hooks and Zustand stores for interacting with decentralized communities — fetching comments, feeds, author data, publishing, account management, and more.
+bitsocial-react-hooks (`@bitsocial/bitsocial-react-hooks`) is a React hooks library for the Bitsocial protocol. It provides React hooks and Zustand stores for interacting with decentralized communities — fetching comments, feeds, author data, publishing, account management, and more.
 
 This repository is its own project under the bitsocialnet org. Use `pkc`, `community`, and `pkc-js` naming consistently in code, tests, docs, and file names.
 
@@ -95,6 +95,7 @@ src/
 - If the user asks for a reviewable feature/fix/docs/chore and the current branch is `master`, create a short-lived task branch before making code changes unless the user explicitly asks to work directly on `master`.
 - Name short-lived branches by intent: `feature/*`, `fix/*`, `docs/*`, `chore/*`.
 - Open PRs from task branches into `master` so review bots and humans can inspect the actual change before merge.
+- Never open draft PRs. PRs created by agents must be ready for review unless the user explicitly asks not to open a PR yet.
 - Prefer short-lived task branches over a long-lived `develop` branch unless the user explicitly asks for a staging-branch workflow.
 - Use worktrees only when parallel tasks need isolated checkouts. One active task branch per worktree.
 - If a new task is unrelated to the currently checked out branch, do not stack it on that branch. Create a new worktree from `master` and create a separate short-lived task branch there.
@@ -111,7 +112,7 @@ src/
 
 - Prefer `pkc`, `community`, and `pkc-js` naming in new or renamed code.
 - Do not introduce or preserve older protocol naming in code, tests, docs, or migrations unless the user explicitly asks for a compatibility bridge.
-- Package name and import path is `@bitsocialnet/bitsocial-react-hooks`. Use this in README examples and docs.
+- Package name and import path is `@bitsocial/bitsocial-react-hooks`. Use this in README examples and docs.
 
 ### Bug Investigation Rules
 

--- a/README.md
+++ b/README.md
@@ -11,15 +11,14 @@
 
 React hooks for the Bitsocial protocol. Build decentralized, serverless social apps with React using a familiar hooks API — fetch feeds, comments, author profiles, manage accounts, publish content, and more, all without a central server.
 
-This package is currently consumed directly from [`bitsocialnet/bitsocial-react-hooks`](https://github.com/bitsocialnet/bitsocial-react-hooks) and is used by [5chan](https://github.com/bitsocialnet/5chan) and other Bitsocial clients.
+This package is published as [`@bitsocial/bitsocial-react-hooks`](https://www.npmjs.com/package/@bitsocial/bitsocial-react-hooks) and is used by [5chan](https://github.com/bitsocialnet/5chan) and other Bitsocial clients.
 
 ## Installation
 
 ```bash
-yarn add https://github.com/bitsocialnet/bitsocial-react-hooks.git#<commit-hash>
+yarn add @bitsocial/bitsocial-react-hooks
 ```
 
-Use a pinned commit hash (or tag) so installs are reproducible.
 The published build is self-contained ESM, so consumers should not need postinstall import-rewrite patches.
 
 ## Development Setup
@@ -212,7 +211,7 @@ deleteCaches() // delete the cached comments, cached communities and cached page
 #### Getting started
 
 ```jsx
-import { useComment, useAccount } from "@bitsocialnet/bitsocial-react-hooks";
+import { useComment, useAccount } from "@bitsocial/bitsocial-react-hooks";
 
 const account = useAccount();
 const comment = useComment({ commentCid });
@@ -232,7 +231,7 @@ import {
   useAccounts,
   createAccount,
   setActiveAccount,
-} from "@bitsocialnet/bitsocial-react-hooks";
+} from "@bitsocial/bitsocial-react-hooks";
 
 const account = useAccount();
 const { accounts } = useAccounts();
@@ -718,7 +717,7 @@ await abandonPublish();
 **2. Delete by index or CID** — remove any of your comments (pending or published):
 
 ```jsx
-import { deleteComment, useAccountComments } from "@bitsocialnet/bitsocial-react-hooks";
+import { deleteComment, useAccountComments } from "@bitsocial/bitsocial-react-hooks";
 
 // By account comment index (from usePublishComment or useAccountComment)
 const { index, publishComment } = usePublishComment(publishCommentOptions);
@@ -736,7 +735,7 @@ await deleteComment(accountComment.cid);
 **Common cleanup pattern (remove failed UI clutter):**
 
 ```jsx
-import { deleteComment, useAccountComments } from "@bitsocialnet/bitsocial-react-hooks";
+import { deleteComment, useAccountComments } from "@bitsocial/bitsocial-react-hooks";
 
 const { accountComments } = useAccountComments();
 const failedComments = accountComments.filter((comment) => comment.state === "failed");
@@ -876,7 +875,7 @@ console.log(error);
 #### Edit an account
 
 ```jsx
-import {useAccount, setAccount, useResolvedAuthorAddress} from '@bitsocialnet/bitsocial-react-hooks'
+import {useAccount, setAccount, useResolvedAuthorAddress} from '@bitsocial/bitsocial-react-hooks'
 const account = useAccount() // or useAccount('Account 2') to use an account other than the active one
 
 // `account.author.wallets` only auto-generates an `eth` wallet by default.
@@ -924,7 +923,7 @@ if (state === 'resolving' && nameResolver) {
 > Note: deleting account is unrecoverable, warn the user to export/backup his account before deleting
 
 ```jsx
-import { deleteAccount } from "@bitsocialnet/bitsocial-react-hooks";
+import { deleteAccount } from "@bitsocial/bitsocial-react-hooks";
 
 // delete active account
 await deleteAccount();
@@ -1181,7 +1180,7 @@ import {
   importAccount,
   setActiveAccount,
   setAccountsOrder,
-} from "@bitsocialnet/bitsocial-react-hooks";
+} from "@bitsocial/bitsocial-react-hooks";
 
 // get active account 'Account 1'
 const activeAccount = useAccount();
@@ -1276,7 +1275,7 @@ const { accountEdits } = useAccountEdits({ filter });
 #### Get replies to a post (nested or flat)
 
 ```jsx
-import { useReplies, useComment, useAccountComment } from "@bitsocialnet/bitsocial-react-hooks";
+import { useReplies, useComment, useAccountComment } from "@bitsocial/bitsocial-react-hooks";
 
 // NOTE: recommended to use the same replies options for all depths, or will load slower
 const useRepliesOptions = {
@@ -1339,7 +1338,7 @@ const repliesComponents = replies.map((reply, index) => (
 #### Format short CIDs and addresses
 
 ```jsx
-import { useShortAddress, useShortCid } from "@bitsocialnet/bitsocial-react-hooks";
+import { useShortAddress, useShortCid } from "@bitsocial/bitsocial-react-hooks";
 
 const shortParentCid = useShortCid(comment.parentCid);
 const shortAddress = useShortAddress(address);

--- a/docs/clients.md
+++ b/docs/clients.md
@@ -2,7 +2,7 @@
 
 ```js
 import { useMemo } from "react";
-import { useClientsStates } from "@bitsocialnet/bitsocial-react-hooks";
+import { useClientsStates } from "@bitsocial/bitsocial-react-hooks";
 
 const clientHosts = {};
 const getClientHost = (clientUrl) => {
@@ -129,7 +129,7 @@ if (errorString) {
 
 ```js
 import { useMemo } from "react";
-import { useCommunity, useCommunitiesStates } from "@bitsocialnet/bitsocial-react-hooks";
+import { useCommunity, useCommunitiesStates } from "@bitsocial/bitsocial-react-hooks";
 
 const clientHosts = {};
 const getClientHost = (clientUrl) => {

--- a/docs/mock-content.md
+++ b/docs/mock-content.md
@@ -18,7 +18,7 @@ REACT_APP_BITSOCIAL_REACT_HOOKS_MOCK_CONTENT_LOADING_TIME=1000
 #### Get a mock feed
 
 ```js
-import { useFeed } from "@bitsocialnet/bitsocial-react-hooks";
+import { useFeed } from "@bitsocial/bitsocial-react-hooks";
 
 function App() {
   const { feed, hasMore, loadMore } = useFeed({
@@ -41,7 +41,7 @@ REACT_APP_BITSOCIAL_REACT_HOOKS_NO_CACHE=1
 #### Delete databases and caches
 
 ```js
-import { deleteCaches, deleteDatabases } from "@bitsocialnet/bitsocial-react-hooks";
+import { deleteCaches, deleteDatabases } from "@bitsocial/bitsocial-react-hooks";
 
 // delete all databases, including all caches and accounts data
 await deleteDatabases();

--- a/package.json
+++ b/package.json
@@ -1,11 +1,14 @@
 {
-  "name": "@bitsocialnet/bitsocial-react-hooks",
+  "name": "@bitsocial/bitsocial-react-hooks",
   "type": "module",
   "author": "Bitsocial Forge",
   "keywords": [
     "bitsocial"
   ],
-  "repository": "github:bitsocialnet/bitsocial-react-hooks",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/bitsocialnet/bitsocial-react-hooks.git"
+  },
   "license": "GPL-3.0-or-later",
   "publishConfig": {
     "access": "public"
@@ -42,8 +45,8 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.6",
-    "@pkc/pkc-logger": "https://github.com/pkcprotocol/pkc-logger.git",
     "@pkcprotocol/pkc-js": "0.0.18",
+    "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",
     "localforage": "1.10.0",

--- a/src/hooks/accounts/accounts.ts
+++ b/src/hooks/accounts/accounts.ts
@@ -2,7 +2,7 @@ import { useMemo, useState, useEffect } from "react";
 import isEqual from "lodash.isequal";
 import useAccountsStore from "../../stores/accounts";
 import useCommunitiesStore from "../../stores/communities";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:accounts:hooks");
 import assert from "assert";
 import { useListCommunities, useCommunities } from "../communities";

--- a/src/hooks/accounts/utils.ts
+++ b/src/hooks/accounts/utils.ts
@@ -15,7 +15,7 @@ import { useMemo, useState, useEffect } from "react";
 import memoize from "memoizee";
 import utils from "../../lib/utils";
 import PkcJs from "../../lib/pkc-js";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:accounts:hooks");
 
 export const useCalculatedNotifications = (

--- a/src/hooks/actions/actions.ts
+++ b/src/hooks/actions/actions.ts
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useState } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import useAccountsStore from "../../stores/accounts";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:actions:hooks");
 import assert from "assert";
 import { useAccount, useAccountId } from "../accounts";

--- a/src/hooks/authors/author-avatars.ts
+++ b/src/hooks/authors/author-avatars.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState, useMemo } from "react";
 import { useAccount } from "../accounts";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:authors:hooks");
 import assert from "assert";
 import { Nft, ChainProviders, Author } from "../../types";

--- a/src/hooks/authors/authors.ts
+++ b/src/hooks/authors/authors.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import useInterval from "../utils/use-interval";
 import { useAccount } from "../accounts";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:authors:hooks");
 import assert from "assert";
 import {

--- a/src/hooks/comments.ts
+++ b/src/hooks/comments.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useAccount } from "./accounts";
 import validator from "../lib/validator";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:comments:hooks");
 import assert from "assert";
 import {

--- a/src/hooks/communities.ts
+++ b/src/hooks/communities.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useAccount } from "./accounts";
 import validator from "../lib/validator";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:communities:hooks");
 import assert from "assert";
 import {

--- a/src/hooks/feeds/feeds.ts
+++ b/src/hooks/feeds/feeds.ts
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useAccount } from "../accounts";
 import validator from "../../lib/validator";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:feeds:hooks");
 import assert from "assert";
 import { deriveFeedSortType } from "../../lib/feed-sort-type";

--- a/src/hooks/replies.ts
+++ b/src/hooks/replies.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState, useMemo } from "react";
 import { useAccount } from "./accounts";
 import validator from "../lib/validator";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:replies:hooks");
 import assert from "assert";
 import { UseRepliesOptions, UseRepliesResult } from "../types";

--- a/src/hooks/states.ts
+++ b/src/hooks/states.ts
@@ -1,5 +1,5 @@
 import { useMemo } from "react";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:states:hooks");
 import assert from "assert";
 import validator from "../lib/validator";

--- a/src/lib/localforage-lru/index.ts
+++ b/src/lib/localforage-lru/index.ts
@@ -5,7 +5,7 @@ try {
   if (process.env.REACT_APP_BITSOCIAL_REACT_HOOKS_NO_CACHE) {
     // @ts-ignore
     localForageLru.createInstance = () => {
-      console.warn("@bitsocialnet/bitsocial-react-hooks cache is disabled for testing");
+      console.warn("@bitsocial/bitsocial-react-hooks cache is disabled for testing");
       return {
         getItem: async function (key: string) {},
         setItem: async function (key: string, value: any) {},

--- a/src/lib/pkc-js/index.ts
+++ b/src/lib/pkc-js/index.ts
@@ -1,7 +1,7 @@
 // NOTE: don't import pkc-js directly to be able to replace the implementation
 
 import PkcJsMockContent from "./pkc-js-mock-content";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 import assert from "assert";
 const log = Logger("bitsocial-react-hooks:pkc-js");
 

--- a/src/lib/utils/utils.ts
+++ b/src/lib/utils/utils.ts
@@ -1,6 +1,6 @@
 import assert from "assert";
 import QuickLru from "quick-lru";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 import PkcJs from "../pkc-js";
 import { Comment } from "../../types";
 import { areEquivalentCommunityAddresses } from "../community-address";

--- a/src/stores/accounts/account-generator.ts
+++ b/src/stores/accounts/account-generator.ts
@@ -9,7 +9,7 @@ import {
   normalizeAccountProtocolConfig,
   withProtocolAliases,
 } from "../../lib/pkc-compat";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:accounts:stores");
 
 export const DEFAULT_ETH_RPC_URL = "https://ethereum-rpc.publicnode.com";

--- a/src/stores/accounts/accounts-actions-internal.ts
+++ b/src/stores/accounts/accounts-actions-internal.ts
@@ -2,7 +2,7 @@
 
 import accountsStore, { listeners } from "./accounts-store";
 import accountsDatabase from "./accounts-database";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 import assert from "assert";
 import isEqual from "lodash.isequal";
 const log = Logger("bitsocial-react-hooks:accounts:stores");

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -4,7 +4,7 @@ import accountsStore, { listeners } from "./accounts-store";
 import communitiesStore from "../communities";
 import accountsDatabase from "./accounts-database";
 import accountGenerator from "./account-generator";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 import validator from "../../lib/validator";
 import chain from "../../lib/chain";
 import assert from "assert";

--- a/src/stores/accounts/accounts-database.ts
+++ b/src/stores/accounts/accounts-database.ts
@@ -29,7 +29,7 @@ import {
   normalizeAccountProtocolConfig,
   withProtocolAliases,
 } from "../../lib/pkc-compat";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:accounts:stores");
 // Storage keeps the existing namespace so current installs reuse the same IndexedDB data.
 const accountsDatabaseNamespace = "bitsocialReactHooks";

--- a/src/stores/accounts/accounts-store.ts
+++ b/src/stores/accounts/accounts-store.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:accounts:stores");
 import accountsDatabase from "./accounts-database";
 import accountGenerator from "./account-generator";

--- a/src/stores/accounts/utils.ts
+++ b/src/stores/accounts/utils.ts
@@ -12,7 +12,7 @@ import {
   AccountEditsSummary,
 } from "../../types";
 import assert from "assert";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:accounts:stores");
 import commentsStore from "../comments";
 import repliesPagesStore from "../replies-pages";

--- a/src/stores/authors-comments/authors-comments-store.ts
+++ b/src/stores/authors-comments/authors-comments-store.ts
@@ -1,4 +1,4 @@
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:authors:stores");
 import createStore from "zustand";
 import assert from "assert";

--- a/src/stores/comments/comments-store.ts
+++ b/src/stores/comments/comments-store.ts
@@ -3,7 +3,7 @@ const commentsDatabase = localForageLru.createInstance({
   name: "bitsocialReactHooks-comments",
   size: 5000,
 });
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 export const log = Logger("bitsocial-react-hooks:comments:stores");
 import { Comment, Comments, Account } from "../../types";
 import utils from "../../lib/utils";

--- a/src/stores/communities-pages/communities-pages-store.ts
+++ b/src/stores/communities-pages/communities-pages-store.ts
@@ -1,5 +1,5 @@
 import utils from "../../lib/utils";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 // include communities pages store with feeds for debugging
 export const log = Logger("bitsocial-react-hooks:feeds:stores");
 import {

--- a/src/stores/communities/communities-store.ts
+++ b/src/stores/communities/communities-store.ts
@@ -4,7 +4,7 @@ const communitiesDatabase = localForageLru.createInstance({
   name: "bitsocialReactHooks-communities",
   size: 500,
 });
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:communities:stores");
 import {
   Community,

--- a/src/stores/feeds/feeds-store.ts
+++ b/src/stores/feeds/feeds-store.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:feeds:stores");
 import {
   Feed,

--- a/src/stores/feeds/utils.ts
+++ b/src/stores/feeds/utils.ts
@@ -24,7 +24,7 @@ import {
   getCommunityRefKeys,
   getMatchingCommunityRefKeys,
 } from "../../lib/community-ref";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:feeds:stores");
 
 const getFeedCommunityRefs = (feedOptions: Partial<FeedOptions>): CommunityLookupRef[] =>

--- a/src/stores/replies-pages/replies-pages-store.ts
+++ b/src/stores/replies-pages/replies-pages-store.ts
@@ -1,5 +1,5 @@
 import utils from "../../lib/utils";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 // include replies pages store with feeds for debugging
 export const log = Logger("bitsocial-react-hooks:replies:stores");
 import { RepliesPage, RepliesPages, Account, Comment, Comments } from "../../types";

--- a/src/stores/replies-pages/utils.ts
+++ b/src/stores/replies-pages/utils.ts
@@ -2,7 +2,7 @@ import { RepliesPage, RepliesFeedOptions, RepliesFeedsOptions, Comment } from ".
 import repliesStore from "../replies";
 import { getSortTypeFromComment } from "../replies/utils";
 import repliesCommentsStore from "../replies/replies-comments-store";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 // include replies pages store with feeds for debugging
 const log = Logger("bitsocial-react-hooks:replies:stores");
 

--- a/src/stores/replies/replies-store.ts
+++ b/src/stores/replies/replies-store.ts
@@ -1,5 +1,5 @@
 import assert from "assert";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:replies:stores");
 import {
   Feed,

--- a/src/stores/replies/utils.ts
+++ b/src/stores/replies/utils.ts
@@ -16,7 +16,7 @@ import repliesSorter from "../feeds/feed-sorter";
 import accountsStore from "../accounts";
 import { flattenCommentsPages, commentIsValid, removeInvalidComments } from "../../lib/utils";
 import { areEquivalentCommunityAddresses } from "../../lib/community-address";
-import Logger from "@pkc/pkc-logger";
+import Logger from "@pkcprotocol/pkc-logger";
 const log = Logger("bitsocial-react-hooks:replies:stores");
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -279,24 +279,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@bitsocial/bso-resolver@npm:0.0.6":
-  version: 0.0.6
-  resolution: "@bitsocial/bso-resolver@npm:0.0.6"
-  dependencies:
-    "@pkcprotocol/pkc-logger": "npm:0.1.0"
-    better-sqlite3: "npm:12.6.2"
-    viem: "npm:2.48.1"
-  checksum: 10c0/113e54c08dd86c1e356318e6be1b2b1682753209bba229256352a47bbaef81d340a46c5124f4abf8f49d1289caae479637e902b45ac33e950fc05a34caf0e044
-  languageName: node
-  linkType: hard
-
-"@bitsocialnet/bitsocial-react-hooks@workspace:.":
+"@bitsocial/bitsocial-react-hooks@workspace:.":
   version: 0.0.0-use.local
-  resolution: "@bitsocialnet/bitsocial-react-hooks@workspace:."
+  resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.6"
-    "@pkc/pkc-logger": "https://github.com/pkcprotocol/pkc-logger.git"
     "@pkcprotocol/pkc-js": "npm:0.0.18"
+    "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
     "@tsconfig/recommended": "npm:1.0.13"
@@ -345,6 +334,17 @@ __metadata:
     react: ">=16.8"
   languageName: unknown
   linkType: soft
+
+"@bitsocial/bso-resolver@npm:0.0.6":
+  version: 0.0.6
+  resolution: "@bitsocial/bso-resolver@npm:0.0.6"
+  dependencies:
+    "@pkcprotocol/pkc-logger": "npm:0.1.0"
+    better-sqlite3: "npm:12.6.2"
+    viem: "npm:2.48.1"
+  checksum: 10c0/113e54c08dd86c1e356318e6be1b2b1682753209bba229256352a47bbaef81d340a46c5124f4abf8f49d1289caae479637e902b45ac33e950fc05a34caf0e044
+  languageName: node
+  linkType: hard
 
 "@chainsafe/as-chacha20poly1305@npm:^0.1.0":
   version: 0.1.0
@@ -2947,15 +2947,6 @@ __metadata:
     tslib: "npm:^2.8.1"
     tsyringe: "npm:^4.10.0"
   checksum: 10c0/949231ca9daf84534bfe255f28a856df497302fed294d227c6a28e50f5cfb67ed1d91afe6db787b88294ce042295243dbcb44455fe2efa5ed07428a74392eec9
-  languageName: node
-  linkType: hard
-
-"@pkc/pkc-logger@https://github.com/pkcprotocol/pkc-logger.git":
-  version: 0.0.1
-  resolution: "@pkc/pkc-logger@https://github.com/pkcprotocol/pkc-logger.git#commit=cb494fbaf332ed5b2cfd9d9d0f90ca7fd0058b4a"
-  dependencies:
-    debug: "npm:4.4.3"
-  checksum: 10c0/7ee44c03de81f87ecbfa104d8db829f692cad8454de2325812af585369d3d637446bace809e82722bd610254b5c82bc3aca99586a8d9b0531ae6dd88194b68d3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- publish the package under `@bitsocial/bitsocial-react-hooks` and update docs/import examples
- switch `pkc-logger` from the GitHub dependency to `@pkcprotocol/pkc-logger` on npm
- add npm trusted publishing to the existing dist commit job, gated on actual dist changes and existing npm versions

## Validation

- `corepack yarn install --immutable`
- `corepack yarn prettier`
- `corepack yarn lint` (passes with existing warnings)
- `corepack yarn type-check`
- `corepack yarn build`
- `npm publish --dry-run --access public --provenance`

## Notes

- `@bitsocial/bitsocial-react-hooks@0.1.0` is already published on npm.
- This workflow publishes only when the package version in `package.json` is not already on npm; it does not auto-bump versions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies the release pipeline to publish to npm from CI and changes the package name/scope, so a misconfiguration could publish the wrong version or break consumers expecting the old scope.
> 
> **Overview**
> Publishes the library as **`@bitsocial/bitsocial-react-hooks`** instead of `@bitsocialnet/*`, updating `package.json` metadata and aligning README/docs import/install examples and user-facing strings.
> 
> Updates logging dependency usage by switching imports from `@pkc/pkc-logger` to the npm package `@pkcprotocol/pkc-logger` (and updating `yarn.lock`).
> 
> Enhances the `dist` CI job to support **npm trusted publishing**: adds `id-token` permission, sets up Node/npm, commits `dist`/coverage artifacts, then conditionally publishes to npm with `--provenance` only when artifacts changed and the `package.json` version is not already published.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc6d658c61825430f17808212e504ce9b387c062. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->