### PR TITLE
chore(deps): bump pkc-js for 0.1.8 release

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.7",
+  "version": "0.1.8",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.8",
-    "@pkcprotocol/pkc-js": "0.0.27",
+    "@pkcprotocol/pkc-js": "0.0.29",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,7 @@ __metadata:
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.8"
-    "@pkcprotocol/pkc-js": "npm:0.0.27"
+    "@pkcprotocol/pkc-js": "npm:0.0.29"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
@@ -2167,6 +2167,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@libp2p/webtransport@npm:6.0.22":
+  version: 6.0.22
+  resolution: "@libp2p/webtransport@npm:6.0.22"
+  dependencies:
+    "@chainsafe/libp2p-noise": "npm:^17.0.0"
+    "@libp2p/interface": "npm:^3.2.2"
+    "@libp2p/peer-id": "npm:^6.0.8"
+    "@libp2p/utils": "npm:^7.1.0"
+    "@multiformats/multiaddr": "npm:^13.0.1"
+    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
+    multiformats: "npm:^13.3.6"
+    progress-events: "npm:^1.0.1"
+    race-signal: "npm:^2.0.0"
+    uint8arraylist: "npm:^2.4.8"
+    uint8arrays: "npm:^5.1.0"
+  checksum: 10c0/152aaf9b2895681b05b243b5fa156eb4c510d655b9880ac105c8963741dae2690e7eef079a1484569e22745a065ea9580ed543121db039ed77327fb715544b32
+  languageName: node
+  linkType: hard
+
 "@multiformats/base-x@npm:^4.0.1":
   version: 4.0.1
   resolution: "@multiformats/base-x@npm:4.0.1"
@@ -3168,9 +3187,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkcprotocol/pkc-js@npm:0.0.27":
-  version: 0.0.27
-  resolution: "@pkcprotocol/pkc-js@npm:0.0.27"
+"@pkcprotocol/pkc-js@npm:0.0.29":
+  version: 0.0.29
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.29"
   dependencies:
     "@enhances/with-resolvers": "npm:0.0.5"
     "@helia/block-brokers": "npm:5.2.4"
@@ -3183,6 +3202,7 @@ __metadata:
     "@libp2p/identify": "npm:4.1.3"
     "@libp2p/interfaces": "npm:3.3.2"
     "@libp2p/peer-id": "npm:6.0.8"
+    "@libp2p/webtransport": "npm:6.0.22"
     "@noble/curves": "npm:2.2.0"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@pkcprotocol/proper-lock-file": "npm:4.2.1"
@@ -3219,7 +3239,7 @@ __metadata:
     typestub-ipfs-only-hash: "npm:4.0.0"
     uuid: "npm:13.0.0"
     zod: "npm:4.3.6"
-  checksum: 10c0/19360d831a9ea3ecb586ca02d1763611224bdcc72f2586dc50ffe1a550a56e72c79f173ebce8422ab15623f277889dd96666016ab042d208fb4d185879b82784
+  checksum: 10c0/089100e75d4b2c735f3a9b9f6b087970afb9dc606e21be6e5e1e84daf2e3350793f5cfa8f6508a3db7bc518a1173e517f449174185b2a07f5df7d33f73cffdac
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bump `@pkcprotocol/pkc-js` from `0.0.27` to `0.0.29`
- Bump `@bitsocial/bitsocial-react-hooks` to `0.1.8` for the next CI release

## Verification

- `yarn install`
- `yarn build`
- `yarn test`
- `yarn prettier`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> No source code changes, but updating a core dependency (`@pkcprotocol/pkc-js`) may change runtime behavior due to new/transitive networking deps (e.g., `@libp2p/webtransport`).
> 
> **Overview**
> Updates the published package version from `0.1.7` to `0.1.8`.
> 
> Bumps dependency `@pkcprotocol/pkc-js` from `0.0.27` to `0.0.29` and refreshes `yarn.lock`, including pulling in new transitive dependency `@libp2p/webtransport`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit becbfe9836e54c37d4603c5b6e2ede6f6438797d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped package version to 0.1.8
  * Updated dependencies to latest compatible versions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->