### PR TITLE
fix(deps): upgrade pkc-js to 0.0.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.8",
+  "version": "0.1.9",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.8",
-    "@pkcprotocol/pkc-js": "0.0.29",
+    "@pkcprotocol/pkc-js": "0.0.30",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,7 @@ __metadata:
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.8"
-    "@pkcprotocol/pkc-js": "npm:0.0.29"
+    "@pkcprotocol/pkc-js": "npm:0.0.30"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
@@ -3187,9 +3187,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkcprotocol/pkc-js@npm:0.0.29":
-  version: 0.0.29
-  resolution: "@pkcprotocol/pkc-js@npm:0.0.29"
+"@pkcprotocol/pkc-js@npm:0.0.30":
+  version: 0.0.30
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.30"
   dependencies:
     "@enhances/with-resolvers": "npm:0.0.5"
     "@helia/block-brokers": "npm:5.2.4"
@@ -3239,7 +3239,7 @@ __metadata:
     typestub-ipfs-only-hash: "npm:4.0.0"
     uuid: "npm:13.0.0"
     zod: "npm:4.3.6"
-  checksum: 10c0/089100e75d4b2c735f3a9b9f6b087970afb9dc606e21be6e5e1e84daf2e3350793f5cfa8f6508a3db7bc518a1173e517f449174185b2a07f5df7d33f73cffdac
+  checksum: 10c0/b6fa8a8e6474d4d7150c6fd29ac8caef9a8d1fd67a2444f9b3e4354ed95b80427693387618363eb059ad4775834857e58ca8fb5b85c9daafc795a16349b34d11
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- upgrade @pkcprotocol/pkc-js to 0.0.30
- bump @bitsocial/bitsocial-react-hooks to 0.1.9 for release

## Verification
- yarn prettier
- yarn test
- yarn build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it upgrades a core external dependency (`@pkcprotocol/pkc-js`), which could change runtime behavior or APIs even though no application code was modified.
> 
> **Overview**
> Updates `@pkcprotocol/pkc-js` from `0.0.29` to `0.0.30` (including `yarn.lock` resolution/checksum updates).
> 
> Bumps the package version from `0.1.8` to `0.1.9` for the release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9942a82def8330e49a8252653a7bc16abd6819a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->