### PR TITLE
chore(release): prepare v0.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.9",
+  "version": "0.1.10",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.8",
-    "@pkcprotocol/pkc-js": "0.0.30",
+    "@pkcprotocol/pkc-js": "0.0.33",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,7 @@ __metadata:
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.8"
-    "@pkcprotocol/pkc-js": "npm:0.0.30"
+    "@pkcprotocol/pkc-js": "npm:0.0.33"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
@@ -2167,25 +2167,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@libp2p/webtransport@npm:6.0.22":
-  version: 6.0.22
-  resolution: "@libp2p/webtransport@npm:6.0.22"
-  dependencies:
-    "@chainsafe/libp2p-noise": "npm:^17.0.0"
-    "@libp2p/interface": "npm:^3.2.2"
-    "@libp2p/peer-id": "npm:^6.0.8"
-    "@libp2p/utils": "npm:^7.1.0"
-    "@multiformats/multiaddr": "npm:^13.0.1"
-    "@multiformats/multiaddr-matcher": "npm:^3.0.1"
-    multiformats: "npm:^13.3.6"
-    progress-events: "npm:^1.0.1"
-    race-signal: "npm:^2.0.0"
-    uint8arraylist: "npm:^2.4.8"
-    uint8arrays: "npm:^5.1.0"
-  checksum: 10c0/152aaf9b2895681b05b243b5fa156eb4c510d655b9880ac105c8963741dae2690e7eef079a1484569e22745a065ea9580ed543121db039ed77327fb715544b32
-  languageName: node
-  linkType: hard
-
 "@multiformats/base-x@npm:^4.0.1":
   version: 4.0.1
   resolution: "@multiformats/base-x@npm:4.0.1"
@@ -3187,9 +3168,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkcprotocol/pkc-js@npm:0.0.30":
-  version: 0.0.30
-  resolution: "@pkcprotocol/pkc-js@npm:0.0.30"
+"@pkcprotocol/pkc-js@npm:0.0.33":
+  version: 0.0.33
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.33"
   dependencies:
     "@enhances/with-resolvers": "npm:0.0.5"
     "@helia/block-brokers": "npm:5.2.4"
@@ -3202,7 +3183,6 @@ __metadata:
     "@libp2p/identify": "npm:4.1.3"
     "@libp2p/interfaces": "npm:3.3.2"
     "@libp2p/peer-id": "npm:6.0.8"
-    "@libp2p/webtransport": "npm:6.0.22"
     "@noble/curves": "npm:2.2.0"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@pkcprotocol/proper-lock-file": "npm:4.2.1"
@@ -3239,7 +3219,7 @@ __metadata:
     typestub-ipfs-only-hash: "npm:4.0.0"
     uuid: "npm:13.0.0"
     zod: "npm:4.3.6"
-  checksum: 10c0/b6fa8a8e6474d4d7150c6fd29ac8caef9a8d1fd67a2444f9b3e4354ed95b80427693387618363eb059ad4775834857e58ca8fb5b85c9daafc795a16349b34d11
+  checksum: 10c0/4e3cfc1a1965dd7bf7bba635c9696f51649c5b72c52feca383cde36ca387651c278bf3135b7d9b2de920818166b2c4bb1c6393aa62254aaf5b2e50d6c110d6ef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Bump @bitsocial/bitsocial-react-hooks to 0.1.10.
- Upgrade @pkcprotocol/pkc-js from 0.0.30 to 0.0.33.
- Refresh the Yarn lockfile for the dependency change.

## Verification
- Confirmed @pkcprotocol/pkc-js@0.0.33 exists on npm.
- Confirmed @bitsocial/bitsocial-react-hooks@0.1.10 is not already published.
- Ran yarn install.
- Ran yarn build.
- Ran yarn test.

## Release
Merging this PR into master should trigger the existing CI release path for v0.1.10.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk release bump that updates a single dependency and regenerates `yarn.lock`; runtime behavior only changes insofar as `@pkcprotocol/pkc-js` differs between 0.0.30 and 0.0.33.
> 
> **Overview**
> Bumps the package version to `0.1.10` and upgrades `@pkcprotocol/pkc-js` from `0.0.30` to `0.0.33`.
> 
> Refreshes `yarn.lock` to reflect the updated dependency graph (including removal of the locked `@libp2p/webtransport` entry previously pulled in by `@pkcprotocol/pkc-js`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36141b9ce0e415478f6c33f03445201f915cd2ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->