### PR TITLE
fix(communities): suppress retriable load errors

### DIFF
--- a/src/stores/communities/communities-store.test.ts
+++ b/src/stores/communities/communities-store.test.ts
@@ -451,6 +451,87 @@ describe("communities store", () => {
     }
   });
 
+  test("community retriable error event stays out of store errors", async () => {
+    const address = "retriable-error-address";
+    const pkc = await PkcJsMock();
+    const community = await pkc.createCommunity({ address });
+    const updateSpy = vi.spyOn(community, "update").mockResolvedValue(undefined);
+    const createOrig = mockAccount.pkc.createCommunity;
+    mockAccount.pkc.createCommunity = vi.fn().mockResolvedValue(community);
+
+    try {
+      await act(async () => {
+        await communitiesStore.getState().addCommunityToStore(address, mockAccount);
+      });
+
+      vi.useFakeTimers();
+      const error = Object.assign(new Error("transient fetch failed"), {
+        details: { retriableError: true },
+      });
+      act(() => {
+        community.emit("error", error);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(communitiesStore.getState().errors[address]).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+      mockAccount.pkc.createCommunity = createOrig;
+      updateSpy.mockRestore();
+    }
+  });
+
+  test("community non-retriable error event still reaches store errors", async () => {
+    const address = "non-retriable-error-address";
+    const pkc = await PkcJsMock();
+    const community = await pkc.createCommunity({ address });
+    const updateSpy = vi.spyOn(community, "update").mockResolvedValue(undefined);
+    const createOrig = mockAccount.pkc.createCommunity;
+    mockAccount.pkc.createCommunity = vi.fn().mockResolvedValue(community);
+
+    try {
+      await act(async () => {
+        await communitiesStore.getState().addCommunityToStore(address, mockAccount);
+      });
+
+      vi.useFakeTimers();
+      const error = Object.assign(new Error("final fetch failed"), {
+        details: { retriableError: false },
+      });
+      const laterError = Object.assign(new Error("later final fetch failed"), {
+        details: { retriableError: false },
+      });
+      act(() => {
+        community.emit("error", error);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(communitiesStore.getState().errors[address]).toBeUndefined();
+
+      act(() => {
+        community.emit("error", laterError);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(communitiesStore.getState().errors[address]).toEqual([error]);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(500);
+      });
+      expect(communitiesStore.getState().errors[address]).toEqual([error, laterError]);
+    } finally {
+      vi.useRealTimers();
+      mockAccount.pkc.createCommunity = createOrig;
+      updateSpy.mockRestore();
+    }
+  });
+
   test("community update event discards earlier pending and stored errors", async () => {
     const address = "stale-error-address";
     const pkc = await PkcJsMock();

--- a/src/stores/communities/communities-store.test.ts
+++ b/src/stores/communities/communities-store.test.ts
@@ -577,6 +577,41 @@ describe("communities store", () => {
     }
   });
 
+  test("community error timeout is ignored when pending entry was already cleared", async () => {
+    const address = "cleared-pending-error-address";
+    const pkc = await PkcJsMock();
+    const community = await pkc.createCommunity({ address });
+    const updateSpy = vi.spyOn(community, "update").mockResolvedValue(undefined);
+    const createOrig = mockAccount.pkc.createCommunity;
+    mockAccount.pkc.createCommunity = vi.fn().mockResolvedValue(community);
+    let clearTimeoutSpy: { mockRestore: () => void } | undefined;
+
+    try {
+      await act(async () => {
+        await communitiesStore.getState().addCommunityToStore(address, mockAccount);
+      });
+
+      vi.useFakeTimers();
+      clearTimeoutSpy = vi.spyOn(globalThis, "clearTimeout").mockImplementation(() => undefined);
+      const pendingError = new Error("cleared pending fetch failed");
+      act(() => {
+        community.emit("error", pendingError);
+        community.emit("update", community);
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+
+      expect(communitiesStore.getState().errors[address]).toBeUndefined();
+    } finally {
+      clearTimeoutSpy?.mockRestore();
+      vi.useRealTimers();
+      mockAccount.pkc.createCommunity = createOrig;
+      updateSpy.mockRestore();
+    }
+  });
+
   test("createCommunity with no signer asserts address must be undefined", async () => {
     const pkc = await PkcJsMock();
     const community = await pkc.createCommunity({ address: "new-sub-address" });

--- a/src/stores/communities/communities-store.ts
+++ b/src/stores/communities/communities-store.ts
@@ -139,11 +139,18 @@ const scheduleCommunityError = (setState: Function, communityKey: string, error:
   }
 
   const timeout = setTimeout(() => {
-    pendingCommunityErrorTimers[communityKey] = pendingCommunityErrorTimers[communityKey].filter(
+    const pendingTimeouts = pendingCommunityErrorTimers[communityKey];
+    if (!pendingTimeouts?.includes(timeout)) {
+      return;
+    }
+
+    const remainingTimeouts = pendingTimeouts.filter(
       (pendingTimeout) => pendingTimeout !== timeout,
     );
-    if (pendingCommunityErrorTimers[communityKey].length === 0) {
+    if (remainingTimeouts.length === 0) {
       delete pendingCommunityErrorTimers[communityKey];
+    } else {
+      pendingCommunityErrorTimers[communityKey] = remainingTimeouts;
     }
     setState((state: CommunitiesState) => {
       const communityErrors = state.errors[communityKey] || [];

--- a/src/stores/communities/communities-store.ts
+++ b/src/stores/communities/communities-store.ts
@@ -123,12 +123,26 @@ const clearStoredCommunityErrors = (state: CommunitiesState, communityKey: strin
   return nextErrors;
 };
 
+const isRetriableCommunityLoadError = (error: Error) => {
+  const details = (error as Error & { details?: unknown }).details;
+  return Boolean(
+    details &&
+    typeof details === "object" &&
+    "retriableError" in details &&
+    (details as { retriableError?: unknown }).retriableError === true,
+  );
+};
+
 const scheduleCommunityError = (setState: Function, communityKey: string, error: Error) => {
+  if (isRetriableCommunityLoadError(error)) {
+    return;
+  }
+
   const timeout = setTimeout(() => {
-    pendingCommunityErrorTimers[communityKey] = (
-      pendingCommunityErrorTimers[communityKey] || []
-    ).filter((pendingTimeout) => pendingTimeout !== timeout);
-    if ((pendingCommunityErrorTimers[communityKey] || []).length === 0) {
+    pendingCommunityErrorTimers[communityKey] = pendingCommunityErrorTimers[communityKey].filter(
+      (pendingTimeout) => pendingTimeout !== timeout,
+    );
+    if (pendingCommunityErrorTimers[communityKey].length === 0) {
       delete pendingCommunityErrorTimers[communityKey];
     }
     setState((state: CommunitiesState) => {


### PR DESCRIPTION
## Summary
- suppress community-store error scheduling for pkc-js errors marked `details.retriableError === true`
- keep non-retriable community errors visible after the existing grace delay
- add regression coverage for retriable and non-retriable community error events

## Verification
- `yarn prettier`
- `yarn test`
- `yarn build`
- `git diff --check`
- `yarn test:coverage:hooks-stores` ran all tests successfully; the strict coverage verifier still exits nonzero on existing unrelated hook/store coverage gaps. The touched `src/stores/communities/communities-store.ts` reports 100% statements/branches/functions/lines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to community error scheduling in the Zustand store with regression tests; no auth, payments, or API contract changes.
> 
> **Overview**
> Community load errors from pkc-js that set **`details.retriableError === true`** are no longer queued into the communities store’s delayed error list, so transient fetch failures should not surface in UI error state after the grace period.
> 
> **Non-retriable** errors still use the existing **1s** grace delay and accumulate per community. The delayed callback now **bails out** if its timeout was already removed from the pending list (e.g. after a successful **`update`** clears pending timers), avoiding stale errors being written back.
> 
> Tests cover retriable suppression, non-retriable batching, and cleared-pending timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04ae6f25d8a812316949b2da941a58002ae0afe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling to filter retriable errors from the error state, ensuring only critical errors are displayed and reducing clutter in the error list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/bitsocialnet/bitsocial-react-hooks/pull/59?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->