### PR TITLE
fix(accounts): preserve challenge comment updates

### DIFF
--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -488,18 +488,24 @@ describe("accounts-actions", () => {
         const publication: any = await createComment(opts);
         vi.spyOn(publication, "simulateChallengeVerificationEvent").mockImplementation(() => {
           const cid = "moderated comment cid";
+          const commentUpdate: any = {
+            cid,
+            pendingApproval: true,
+            reason: "AI moderation reason",
+            removed: false,
+          };
+          Object.defineProperties(commentUpdate, {
+            __proto__: { value: { polluted: true }, enumerable: true },
+            constructor: { value: { polluted: true }, enumerable: true },
+            prototype: { value: { polluted: true }, enumerable: true },
+          });
           publication.cid = cid;
           publication.emit("challengeverification", {
             type: "CHALLENGEVERIFICATION",
             challengeRequestId: publication.challengeRequestId,
             challengeAnswerId: publication.challengeAnswerId,
             challengeSuccess: true,
-            commentUpdate: {
-              cid,
-              pendingApproval: true,
-              reason: "AI moderation reason",
-              removed: false,
-            },
+            commentUpdate,
           });
           publication.publishingState = "succeeded";
           publication.emit("publishingstatechange", "succeeded");
@@ -545,6 +551,10 @@ describe("accounts-actions", () => {
         reason: "AI moderation reason",
         removed: false,
       });
+      expect(Object.prototype.hasOwnProperty.call(storedComment, "__proto__")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(storedComment, "constructor")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(storedComment, "prototype")).toBe(false);
+      expect(({} as any).polluted).toBeUndefined();
 
       const persistedComments = await accountsDatabase.getAccountComments(account.id);
       expect(persistedComments[0]).toMatchObject({
@@ -553,6 +563,9 @@ describe("accounts-actions", () => {
         reason: "AI moderation reason",
         removed: false,
       });
+      expect(Object.prototype.hasOwnProperty.call(persistedComments[0], "__proto__")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(persistedComments[0], "constructor")).toBe(false);
+      expect(Object.prototype.hasOwnProperty.call(persistedComments[0], "prototype")).toBe(false);
     });
 
     test("publishVote with accountName uses named account", async () => {

--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -478,6 +478,83 @@ describe("accounts-actions", () => {
       expect(comments.some((c: any) => c.content === "from named account")).toBe(true);
     });
 
+    test("publishComment preserves challenge commentUpdate fields on the account comment", async () => {
+      await act(async () => {
+        await accountsActions.createAccount();
+      });
+      const account = Object.values(accountsStore.getState().accounts)[0];
+      const createComment = account.pkc.createComment.bind(account.pkc);
+      vi.spyOn(account.pkc, "createComment").mockImplementation(async (opts: any) => {
+        const publication: any = await createComment(opts);
+        vi.spyOn(publication, "simulateChallengeVerificationEvent").mockImplementation(() => {
+          const cid = "moderated comment cid";
+          publication.cid = cid;
+          publication.emit("challengeverification", {
+            type: "CHALLENGEVERIFICATION",
+            challengeRequestId: publication.challengeRequestId,
+            challengeAnswerId: publication.challengeAnswerId,
+            challengeSuccess: true,
+            commentUpdate: {
+              cid,
+              pendingApproval: true,
+              reason: "AI moderation reason",
+              removed: false,
+            },
+          });
+          publication.publishingState = "succeeded";
+          publication.emit("publishingstatechange", "succeeded");
+        });
+        return publication;
+      });
+      const onChallengeVerification = vi.fn();
+
+      await act(async () => {
+        await accountsActions.publishComment({
+          communityAddress: "sub.eth",
+          content: "moderated comment",
+          onChallenge: (challenge: any, comment: any) => comment.publishChallengeAnswers(["4"]),
+          onChallengeVerification,
+        });
+      });
+
+      const startedAt = Date.now();
+      while (Date.now() - startedAt < 2000) {
+        await act(async () => {});
+        const comment = accountsStore.getState().accountsComments[account.id]?.[0];
+        if (comment?.reason === "AI moderation reason") {
+          break;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 25));
+      }
+
+      const storedComment = accountsStore.getState().accountsComments[account.id]?.[0];
+      expect(onChallengeVerification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          commentUpdate: expect.objectContaining({ reason: "AI moderation reason" }),
+        }),
+        expect.objectContaining({
+          cid: "moderated comment cid",
+          pendingApproval: true,
+          reason: "AI moderation reason",
+          removed: false,
+        }),
+      );
+      expect(storedComment).toMatchObject({
+        cid: "moderated comment cid",
+        pendingApproval: true,
+        reason: "AI moderation reason",
+        removed: false,
+      });
+
+      const persistedComments = await accountsDatabase.getAccountComments(account.id);
+      expect(persistedComments[0]).toMatchObject({
+        cid: "moderated comment cid",
+        pendingApproval: true,
+        reason: "AI moderation reason",
+        removed: false,
+      });
+    });
+
     test("publishVote with accountName uses named account", async () => {
       await act(async () => {
         await accountsActions.createAccount();

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -77,9 +77,11 @@ const getClientsSnapshotForState = (clients: any): any => {
   return Object.keys(snapshot).length > 0 ? snapshot : undefined;
 };
 
+const unsafeCommentUpdatePropertyNames = new Set(["__proto__", "constructor", "prototype"]);
+
 const applyChallengeVerificationCommentUpdateToPublication = (
   challengeVerification: ChallengeVerification | undefined,
-  publication: any,
+  publication: Record<string, any> | undefined,
 ) => {
   const commentUpdate = challengeVerification?.commentUpdate;
   if (
@@ -92,7 +94,11 @@ const applyChallengeVerificationCommentUpdateToPublication = (
     return;
   }
 
-  Object.assign(publication, commentUpdate);
+  for (const key of Object.keys(commentUpdate)) {
+    if (!unsafeCommentUpdatePropertyNames.has(key)) {
+      publication[key] = commentUpdate[key];
+    }
+  }
 };
 
 const syncCommentClientsSnapshot = (

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -77,6 +77,24 @@ const getClientsSnapshotForState = (clients: any): any => {
   return Object.keys(snapshot).length > 0 ? snapshot : undefined;
 };
 
+const applyChallengeVerificationCommentUpdateToPublication = (
+  challengeVerification: ChallengeVerification | undefined,
+  publication: any,
+) => {
+  const commentUpdate = challengeVerification?.commentUpdate;
+  if (
+    !commentUpdate ||
+    typeof commentUpdate !== "object" ||
+    Array.isArray(commentUpdate) ||
+    !publication ||
+    typeof publication !== "object"
+  ) {
+    return;
+  }
+
+  Object.assign(publication, commentUpdate);
+};
+
 const syncCommentClientsSnapshot = (
   publishSessionId: string,
   accountId: string,
@@ -1129,6 +1147,7 @@ export const publishComment = async (
     activeComment.once(
       "challengeverification",
       async (challengeVerification: ChallengeVerification) => {
+        applyChallengeVerificationCommentUpdateToPublication(challengeVerification, activeComment);
         publishCommentOptions.onChallengeVerification(challengeVerification, activeComment);
         if (!challengeVerification.challengeSuccess && lastChallenge) {
           // publish again automatically on fail
@@ -1203,6 +1222,10 @@ export const publishComment = async (
             // clone the comment or it bugs publishing callbacks
             const updatingComment = await account.pkc.createComment(
               normalizePublicationOptionsForPkc(account.pkc, { ...comment }),
+            );
+            applyChallengeVerificationCommentUpdateToPublication(
+              challengeVerification,
+              updatingComment,
             );
             accountsActionsInternal
               .startUpdatingAccountCommentOnCommentUpdateEvents(


### PR DESCRIPTION
## Summary
- preserve `challengeVerification.commentUpdate` fields on published account comments
- keep pending moderation metadata through the follow-up comment update watcher
- add a regression test for pending approval reason persistence

## Verification
- `yarn prettier`
- `yarn build`
- `yarn test`
- focused account actions regression test

Note: the repo-wide hooks/stores coverage verifier currently fails on pre-existing coverage gaps unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches comment publish and persistence with security-sensitive filtering of `commentUpdate`; scope is limited to accounts publish flow and covered by a new regression test.
> 
> **Overview**
> **`publishComment`** now merges **`challengeVerification.commentUpdate`** onto the in-flight publication and onto the cloned publication used for **`startUpdatingAccountCommentOnCommentUpdateEvents`**, so moderation fields (e.g. **`pendingApproval`**, **`reason`**, **`cid`**) reach stored and persisted account comments instead of being dropped after challenge success.
> 
> Merging uses a small helper that copies only own keys from **`commentUpdate`** and **skips** **`__proto__`**, **`constructor`**, and **`prototype`** to avoid prototype pollution from hostile update payloads.
> 
> A **regression test** simulates a moderated challenge verification (including polluted enumerable keys) and asserts callbacks, in-memory store, and database all keep the expected metadata without unsafe properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5eea80aa33e9fef7c43b31a589ece43d79acfe0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test verifying comment publishing during moderation challenge verification, including propagation and sanitization of comment updates.

* **Bug Fixes**
  * Ensure moderation-provided comment updates are applied to both in-memory and persisted comments, and unsafe properties are ignored to prevent prototype pollution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->