### PR TITLE
feat(actions): add community export hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ usePublishCommentEdit(options: UsePublishCommentEditOptions): UsePublishCommentE
 usePublishCommentModeration(options: UsePublishCommentModerationOptions): UsePublishCommentModerationResult
 usePublishCommunityEdit(options: UsePublishCommunityEditOptions): UsePublishCommunityEditResult
 useCreateCommunity(options: CreateCommunityOptions): {createdCommunity: Community | undefined, createCommunity: Function}
+useExportCommunity(options?: UseExportCommunityOptions): {communityExports: {communityAddress: string, exportId: string}[], exportCommunity: Function}
 ```
 
 #### States Hooks
@@ -1118,6 +1119,33 @@ const communities = useCommunities({
 });
 // or
 const _community = useCommunity({ community: { name: createdCommunity.address } });
+```
+
+#### (Desktop only) Export communities
+
+```jsx
+// Export one community.
+const { communityExports, exportCommunity, state, error } = useExportCommunity({
+  communityAddress: "your-community-address.eth",
+});
+await exportCommunity();
+
+// Export several communities at the same time.
+const exportMany = useExportCommunity({
+  communityAddresses: ["community-1.eth", "community-2.eth"],
+});
+await exportMany.exportCommunity();
+
+// Export every community listed by the active account's pkc client.
+const exportAll = useExportCommunity();
+await exportAll.exportCommunity();
+
+if (state === "succeeded") {
+  console.log("started exports", communityExports);
+}
+if (state === "failed") {
+  console.log("failed to start export", error.message);
+}
 ```
 
 #### (Desktop only) List the communities you created

--- a/README.md
+++ b/README.md
@@ -171,7 +171,13 @@ usePublishCommentEdit(options: UsePublishCommentEditOptions): UsePublishCommentE
 usePublishCommentModeration(options: UsePublishCommentModerationOptions): UsePublishCommentModerationResult
 usePublishCommunityEdit(options: UsePublishCommunityEditOptions): UsePublishCommunityEditResult
 useCreateCommunity(options: CreateCommunityOptions): {createdCommunity: Community | undefined, createCommunity: Function}
-useExportCommunity(options?: UseExportCommunityOptions): {communityExports: {communityAddress: string, exportId: string}[], exportCommunity: Function}
+useExportCommunity(options?: UseExportCommunityOptions): {
+  communityExports: {communityAddress: string, exportId: string}[],
+  exportCommunity: () => Promise<void>,
+  state: string,
+  error: Error | undefined,
+  errors: Error[]
+}
 ```
 
 #### States Hooks

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -201,7 +201,13 @@ usePublishCommentEdit(options: UsePublishCommentEditOptions): UsePublishCommentE
 usePublishCommentModeration(options: UsePublishCommentModerationOptions): UsePublishCommentModerationResult
 usePublishCommunityEdit(options: UsePublishCommunityEditOptions): UsePublishCommunityEditResult
 useCreateCommunity(options: CreateCommunityOptions): {createdCommunity: Community | undefined, createCommunity: Function}
-useExportCommunity(options?: UseExportCommunityOptions): {communityExports: {communityAddress: string, exportId: string}[], exportCommunity: Function}
+useExportCommunity(options?: UseExportCommunityOptions): {
+  communityExports: {communityAddress: string, exportId: string}[],
+  exportCommunity: () => Promise<void>,
+  state: string,
+  error: Error | undefined,
+  errors: Error[]
+}
 ```
 
 #### States Hooks

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -201,6 +201,7 @@ usePublishCommentEdit(options: UsePublishCommentEditOptions): UsePublishCommentE
 usePublishCommentModeration(options: UsePublishCommentModerationOptions): UsePublishCommentModerationResult
 usePublishCommunityEdit(options: UsePublishCommunityEditOptions): UsePublishCommunityEditResult
 useCreateCommunity(options: CreateCommunityOptions): {createdCommunity: Community | undefined, createCommunity: Function}
+useExportCommunity(options?: UseExportCommunityOptions): {communityExports: {communityAddress: string, exportId: string}[], exportCommunity: Function}
 ```
 
 #### States Hooks
@@ -1148,6 +1149,33 @@ const communities = useCommunities({
 });
 // or
 const _community = useCommunity({ community: { name: createdCommunity.address } });
+```
+
+#### (Desktop only) Export communities
+
+```jsx
+// Export one community.
+const { communityExports, exportCommunity, state, error } = useExportCommunity({
+  communityAddress: "your-community-address.eth",
+});
+await exportCommunity();
+
+// Export several communities at the same time.
+const exportMany = useExportCommunity({
+  communityAddresses: ["community-1.eth", "community-2.eth"],
+});
+await exportMany.exportCommunity();
+
+// Export every community listed by the active account's pkc client.
+const exportAll = useExportCommunity();
+await exportAll.exportCommunity();
+
+if (state === "succeeded") {
+  console.log("started exports", communityExports);
+}
+if (state === "failed") {
+  console.log("failed to start export", error.message);
+}
 ```
 
 #### (Desktop only) List the communities you created

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.8",
-    "@pkcprotocol/pkc-js": "0.0.38",
+    "@pkcprotocol/pkc-js": "0.0.41",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",

--- a/src/hooks/actions/actions.test.ts
+++ b/src/hooks/actions/actions.test.ts
@@ -644,6 +644,11 @@ describe("actions", () => {
 
       expect(rendered.result.current[0].state).toBe("ready");
       expect(rendered.result.current[0].communityExports).toEqual([]);
+
+      rendered.rerender([{ communityAddress: "old-export-target.eth" }]);
+
+      expect(rendered.result.current[0].state).toBe("ready");
+      expect(rendered.result.current[0].communityExports).toEqual([]);
     });
 
     test("can export multiple communities", async () => {

--- a/src/hooks/actions/actions.test.ts
+++ b/src/hooks/actions/actions.test.ts
@@ -609,6 +609,43 @@ describe("actions", () => {
       }
     });
 
+    test("returns initializing and hides stale exports when the account becomes unavailable", async () => {
+      rendered.rerender([{ communityAddress: "logout-export.eth" }]);
+      await waitFor(() => rendered.result.current[0].state === "ready");
+
+      await act(async () => {
+        await rendered.result.current[0].exportCommunity();
+      });
+      await waitFor(() => rendered.result.current[0].state === "succeeded");
+
+      const activeAccountId = useAccountsStore.getState().activeAccountId;
+      try {
+        await act(async () => {
+          useAccountsStore.setState({ activeAccountId: undefined });
+        });
+
+        expect(rendered.result.current[0].state).toBe("initializing");
+        expect(rendered.result.current[0].communityExports).toEqual([]);
+      } finally {
+        useAccountsStore.setState({ activeAccountId });
+      }
+    });
+
+    test("returns ready and hides stale exports when export targets change", async () => {
+      rendered.rerender([{ communityAddress: "old-export-target.eth" }]);
+      await waitFor(() => rendered.result.current[0].state === "ready");
+
+      await act(async () => {
+        await rendered.result.current[0].exportCommunity();
+      });
+      await waitFor(() => rendered.result.current[0].state === "succeeded");
+
+      rendered.rerender([{ communityAddress: "new-export-target.eth" }]);
+
+      expect(rendered.result.current[0].state).toBe("ready");
+      expect(rendered.result.current[0].communityExports).toEqual([]);
+    });
+
     test("can export multiple communities", async () => {
       const communityAddresses = ["export-many-1.eth", "export-many-2.eth"];
       rendered.rerender([{ communityAddresses }]);

--- a/src/hooks/actions/actions.test.ts
+++ b/src/hooks/actions/actions.test.ts
@@ -10,6 +10,7 @@ import {
   useBlock,
   useAccount,
   useCreateCommunity,
+  useExportCommunity,
   setPkcJs,
   useAccountVote,
   useAccountComments,
@@ -553,6 +554,143 @@ describe("actions", () => {
       expect(onError).toHaveBeenCalledWith(expect.any(Error));
 
       PKC.prototype.createCommunity = createCommunity;
+    });
+  });
+
+  describe("useExportCommunity", () => {
+    let rendered: any, waitFor: Function;
+
+    beforeEach(async () => {
+      rendered = renderHook<any, any>((options = []) => {
+        const result1 = useExportCommunity(options[0]);
+        const result2 = useExportCommunity(options[1]);
+        return [result1, result2];
+      });
+      waitFor = testUtils.createWaitFor(rendered);
+    });
+
+    afterEach(async () => {
+      await testUtils.resetDatabasesAndStores();
+    });
+
+    test("can export one community", async () => {
+      const communityAddress = "export-one.eth";
+      expect(rendered.result.current[0].communityExports).toEqual([]);
+      expect(typeof rendered.result.current[0].exportCommunity).toBe("function");
+
+      rendered.rerender([{ communityAddress }]);
+      await waitFor(() => rendered.result.current[0].state === "ready");
+
+      await act(async () => {
+        await rendered.result.current[0].exportCommunity();
+      });
+
+      await waitFor(() => rendered.result.current[0].state === "succeeded");
+      expect(rendered.result.current[0].communityExports).toEqual([
+        {
+          communityAddress,
+          exportId: `${communityAddress} export 1`,
+        },
+      ]);
+      expect(rendered.result.current[0].error).toBe(undefined);
+    });
+
+    test("is initializing while the account is unavailable", () => {
+      const activeAccountId = useAccountsStore.getState().activeAccountId;
+      useAccountsStore.setState({ activeAccountId: undefined });
+
+      try {
+        const initializing = renderHook(() =>
+          useExportCommunity({ communityAddress: "initializing-export.eth" }),
+        );
+        expect(initializing.result.current.state).toBe("initializing");
+      } finally {
+        useAccountsStore.setState({ activeAccountId });
+      }
+    });
+
+    test("can export multiple communities", async () => {
+      const communityAddresses = ["export-many-1.eth", "export-many-2.eth"];
+      rendered.rerender([{ communityAddresses }]);
+      await waitFor(() => rendered.result.current[0].state === "ready");
+
+      await act(async () => {
+        await rendered.result.current[0].exportCommunity();
+      });
+
+      await waitFor(() => rendered.result.current[0].state === "succeeded");
+      expect(rendered.result.current[0].communityExports).toEqual([
+        {
+          communityAddress: communityAddresses[0],
+          exportId: `${communityAddresses[0]} export 1`,
+        },
+        {
+          communityAddress: communityAddresses[1],
+          exportId: `${communityAddresses[1]} export 1`,
+        },
+      ]);
+    });
+
+    test("exports listed account communities when no address is provided", async () => {
+      await act(async () => {
+        await useAccountsStore.getState().accountsActions.createCommunity({ title: "Export all" });
+      });
+
+      rendered.rerender([undefined]);
+      await waitFor(() => rendered.result.current[0].state === "ready");
+      await act(async () => {
+        await rendered.result.current[0].exportCommunity();
+      });
+
+      await waitFor(() => rendered.result.current[0].state === "succeeded");
+      expect(rendered.result.current[0].communityExports).toEqual([
+        {
+          communityAddress: "list community address 1",
+          exportId: "list community address 1 export 1",
+        },
+        {
+          communityAddress: "list community address 2",
+          exportId: "list community address 2 export 1",
+        },
+        {
+          communityAddress: "created community address",
+          exportId: "created community address export 1",
+        },
+      ]);
+    });
+
+    test("useExportCommunity onError callback when export fails", async () => {
+      const original = useAccountsStore.getState().accountsActions.exportCommunity;
+      useAccountsStore.setState((state: any) => ({
+        ...state,
+        accountsActions: {
+          ...state.accountsActions,
+          exportCommunity: async () => {
+            throw Error("store exportCommunity error");
+          },
+        },
+      }));
+
+      const onError = vi.fn();
+      rendered.rerender([{ communityAddress: "export-error.eth", onError }]);
+      await waitFor(() => rendered.result.current[0].state === "ready");
+
+      await act(async () => {
+        await rendered.result.current[0].exportCommunity();
+      });
+
+      expect(rendered.result.current[0].state).toBe("failed");
+      expect(rendered.result.current[0].errors.length).toBe(1);
+      expect(rendered.result.current[0].error.message).toBe("store exportCommunity error");
+      expect(onError).toHaveBeenCalledWith(expect.any(Error));
+
+      useAccountsStore.setState((state: any) => ({
+        ...state,
+        accountsActions: {
+          ...state.accountsActions,
+          exportCommunity: original,
+        },
+      }));
     });
   });
 

--- a/src/hooks/actions/actions.ts
+++ b/src/hooks/actions/actions.ts
@@ -50,6 +50,8 @@ import type {
   UseBlockResult,
   UseCreateCommunityOptions,
   UseCreateCommunityResult,
+  UseExportCommunityOptions,
+  UseExportCommunityResult,
   UsePublishVoteOptions,
   UsePublishVoteResult,
   UsePublishCommentEditOptions,
@@ -66,6 +68,7 @@ import type {
   CommunityEdit,
   Vote,
   Community,
+  CommunityExport,
 } from "../../types";
 
 type PublishChallengeAnswers = (challengeAnswers: string[]) => Promise<void>;
@@ -710,4 +713,50 @@ export function useCreateCommunity(options?: UseCreateCommunityOptions): UseCrea
     }),
     [state, errors, createdCommunity, options, accountName],
   );
+}
+
+export function useExportCommunity(options?: UseExportCommunityOptions): UseExportCommunityResult {
+  assert(
+    !options || typeof options === "object",
+    `useExportCommunity options argument '${options}' not an object`,
+  );
+  const { accountName, communityAddress, communityAddresses, onError, ...exportCommunityOptions } =
+    options || {};
+  const accountsActions = useAccountsStore((state) => state.accountsActions);
+  const accountId = useAccountId(accountName);
+  const [errors, setErrors] = useState<Error[]>([]);
+  const [exportingState, setExportingState] = useState<string>();
+  const [communityExports, setCommunityExports] = useState<CommunityExport[]>([]);
+  const targetCommunityAddresses =
+    communityAddresses || (communityAddress ? [communityAddress] : undefined);
+
+  let initialState = "initializing";
+  if (accountId) {
+    initialState = "ready";
+  }
+
+  const exportCommunity = async () => {
+    try {
+      setExportingState("exporting");
+      const communityExports = await accountsActions.exportCommunity(
+        targetCommunityAddresses,
+        exportCommunityOptions,
+        accountName,
+      );
+      setCommunityExports(communityExports);
+      setExportingState("succeeded");
+    } catch (e: any) {
+      setExportingState("failed");
+      setErrors((errors) => [...errors, e]);
+      onError?.(e);
+    }
+  };
+
+  return {
+    communityExports,
+    exportCommunity,
+    state: exportingState || initialState,
+    error: errors[errors.length - 1],
+    errors,
+  };
 }

--- a/src/hooks/actions/actions.ts
+++ b/src/hooks/actions/actions.ts
@@ -735,17 +735,32 @@ export function useExportCommunity(options?: UseExportCommunityOptions): UseExpo
     exportCommunityOptions.includePrivateKey === true,
     exportCommunityOptions.exportPath,
   ]);
-  const [exportingContextKey, setExportingContextKey] = useState<string>();
+  const previousExportContextKeyRef = useRef(exportContextKey);
+  const exportContextVersionRef = useRef(0);
+  if (previousExportContextKeyRef.current !== exportContextKey) {
+    previousExportContextKeyRef.current = exportContextKey;
+    exportContextVersionRef.current += 1;
+  }
+  const [exportingContext, setExportingContext] = useState<{
+    key: string;
+    version: number;
+  }>();
 
   let initialState = "initializing";
   if (accountId) {
     initialState = "ready";
   }
-  const hasCurrentExportState = accountId && exportingContextKey === exportContextKey;
+  const hasCurrentExportState =
+    accountId &&
+    exportingContext?.key === exportContextKey &&
+    exportingContext.version === exportContextVersionRef.current;
 
   const exportCommunity = async () => {
     try {
-      setExportingContextKey(exportContextKey);
+      setExportingContext({
+        key: exportContextKey,
+        version: exportContextVersionRef.current,
+      });
       setExportingState("exporting");
       const communityExports = await accountsActions.exportCommunity(
         targetCommunityAddresses,

--- a/src/hooks/actions/actions.ts
+++ b/src/hooks/actions/actions.ts
@@ -729,14 +729,23 @@ export function useExportCommunity(options?: UseExportCommunityOptions): UseExpo
   const [communityExports, setCommunityExports] = useState<CommunityExport[]>([]);
   const targetCommunityAddresses =
     communityAddresses || (communityAddress ? [communityAddress] : undefined);
+  const exportContextKey = JSON.stringify([
+    accountId || null,
+    targetCommunityAddresses || null,
+    exportCommunityOptions.includePrivateKey === true,
+    exportCommunityOptions.exportPath,
+  ]);
+  const [exportingContextKey, setExportingContextKey] = useState<string>();
 
   let initialState = "initializing";
   if (accountId) {
     initialState = "ready";
   }
+  const hasCurrentExportState = accountId && exportingContextKey === exportContextKey;
 
   const exportCommunity = async () => {
     try {
+      setExportingContextKey(exportContextKey);
       setExportingState("exporting");
       const communityExports = await accountsActions.exportCommunity(
         targetCommunityAddresses,
@@ -753,10 +762,10 @@ export function useExportCommunity(options?: UseExportCommunityOptions): UseExpo
   };
 
   return {
-    communityExports,
+    communityExports: hasCurrentExportState ? communityExports : [],
     exportCommunity,
-    state: exportingState || initialState,
-    error: errors[errors.length - 1],
-    errors,
+    state: hasCurrentExportState ? exportingState! : initialState,
+    error: hasCurrentExportState ? errors[errors.length - 1] : undefined,
+    errors: hasCurrentExportState ? errors : [],
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ import {
   usePublishCommentEdit,
   usePublishCommentModeration,
   usePublishCommunityEdit,
+  useExportCommunity,
 } from "./hooks/actions";
 
 // actions that don't have their own hooks yet
@@ -136,6 +137,7 @@ export {
   usePublishCommentModeration,
   usePublishCommunityEdit,
   useCreateCommunity,
+  useExportCommunity,
   // actions that don't have their own hooks yet
   createAccount,
   deleteAccount,
@@ -208,6 +210,7 @@ const hooks = {
   usePublishCommentModeration,
   usePublishCommunityEdit,
   useCreateCommunity,
+  useExportCommunity,
   // actions that don't have their own hooks yet
   createAccount,
   deleteAccount,

--- a/src/lib/pkc-js/pkc-js-mock.ts
+++ b/src/lib/pkc-js/pkc-js-mock.ts
@@ -296,10 +296,12 @@ export class Community extends EventEmitter {
   updating = false;
   firstUpdate = true;
   address: string | undefined;
+  publicKey: string | undefined;
   title: string | undefined;
   description: string | undefined;
   posts: Pages;
   modQueue: Pages;
+  exportRecords: any[];
   updatedAt: number | undefined;
   statsCid: string | undefined;
   state: string;
@@ -311,12 +313,14 @@ export class Community extends EventEmitter {
       createCommunityOptions?.address ||
       createCommunityOptions?.name ||
       createCommunityOptions?.publicKey;
+    this.publicKey = createCommunityOptions?.publicKey || this.address;
     this.title = createCommunityOptions?.title;
     this.description = createCommunityOptions?.description;
     this.statsCid = "statscid";
     this.state = "stopped";
     this.updatingState = "stopped";
     this.updatedAt = createCommunityOptions?.updatedAt;
+    this.exportRecords = [];
 
     this.posts = new Pages({ community: this });
     // add community.posts from createCommunityOptions
@@ -392,6 +396,27 @@ export class Community extends EventEmitter {
       delete createdOwnerCommunities[this.address];
       delete editedOwnerCommunities[this.address];
     }
+  }
+
+  get exports() {
+    return this.exportRecords.map((record) => ({ ...record }));
+  }
+
+  async export(exportCommunityOptions: any = {}) {
+    if (!this.address) {
+      throw Error(`can't community.export with no community.address`);
+    }
+    const exportRecord = {
+      exportId: `${this.address} export ${this.exportRecords.length + 1}`,
+      name: this.address,
+      publicKey: this.publicKey || this.address,
+      includePrivateKey: exportCommunityOptions.includePrivateKey === true,
+      progress: 1,
+      url: `file://${this.address}.zip`,
+    };
+    this.exportRecords.push(exportRecord);
+    this.emit("exportschange", this.exports);
+    return { exportId: exportRecord.exportId };
   }
 
   simulateUpdateEvent() {

--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -6,7 +6,11 @@ import * as accountsActionsInternal from "./accounts-actions-internal";
 import accountsDatabase from "./accounts-database";
 import accountsStore from "./accounts-store";
 import communitiesStore from "../communities";
-import PkcJsMock, { PKC as BasePkc, Comment as BaseComment } from "../../lib/pkc-js/pkc-js-mock";
+import PkcJsMock, {
+  PKC as BasePkc,
+  Comment as BaseComment,
+  Community as BaseCommunity,
+} from "../../lib/pkc-js/pkc-js-mock";
 import { setPkcJs } from "../../lib/pkc-js";
 import * as protocolCompat from "../../lib/pkc-compat";
 
@@ -668,6 +672,136 @@ describe("accounts-actions", () => {
         sub = await accountsActions.createCommunity({ title: "My sub" }, "CreateSubAccount");
       });
       expect(sub?.address).toBeDefined();
+    });
+
+    test("exportCommunity exports one community from the active account", async () => {
+      const communityExports = await accountsActions.exportCommunity("single-export.eth", {
+        includePrivateKey: true,
+      });
+
+      expect(communityExports).toEqual([
+        {
+          communityAddress: "single-export.eth",
+          exportId: "single-export.eth export 1",
+        },
+      ]);
+    });
+
+    test("exportCommunity exports multiple communities concurrently", async () => {
+      const originalExport = BaseCommunity.prototype.export;
+      let activeExports = 0;
+      let maxActiveExports = 0;
+      BaseCommunity.prototype.export = async function (options: any) {
+        activeExports++;
+        maxActiveExports = Math.max(maxActiveExports, activeExports);
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        const result = await originalExport.call(this, options);
+        activeExports--;
+        return result;
+      };
+
+      try {
+        const communityExports = await accountsActions.exportCommunity([
+          "bulk-export-1.eth",
+          "bulk-export-2.eth",
+        ]);
+
+        expect(communityExports).toEqual([
+          {
+            communityAddress: "bulk-export-1.eth",
+            exportId: "bulk-export-1.eth export 1",
+          },
+          {
+            communityAddress: "bulk-export-2.eth",
+            exportId: "bulk-export-2.eth export 1",
+          },
+        ]);
+        expect(maxActiveExports).toBe(2);
+      } finally {
+        BaseCommunity.prototype.export = originalExport;
+      }
+    });
+
+    test("exportCommunity defaults to account pkc communities", async () => {
+      await act(async () => {
+        await accountsActions.createCommunity({ title: "Export default list" });
+      });
+
+      const communityExports = await accountsActions.exportCommunity();
+
+      expect(communityExports).toEqual([
+        {
+          communityAddress: "list community address 1",
+          exportId: "list community address 1 export 1",
+        },
+        {
+          communityAddress: "list community address 2",
+          exportId: "list community address 2 export 1",
+        },
+        {
+          communityAddress: "created community address",
+          exportId: "created community address export 1",
+        },
+      ]);
+    });
+
+    test("exportCommunity with accountName uses named account", async () => {
+      await act(async () => {
+        await accountsActions.createAccount();
+        await accountsActions.createAccount("ExportSubAccount");
+      });
+
+      const communityExports = await accountsActions.exportCommunity(
+        "named-export.eth",
+        {},
+        "ExportSubAccount",
+      );
+
+      expect(communityExports).toEqual([
+        {
+          communityAddress: "named-export.eth",
+          exportId: "named-export.eth export 1",
+        },
+      ]);
+    });
+
+    test("exportCommunity validates inputs", async () => {
+      const { accounts, activeAccountId } = accountsStore.getState();
+      const account = accounts[activeAccountId || ""];
+      accountsStore.setState({
+        accounts: {
+          ...accounts,
+          [account.id]: { ...account, pkc: { communities: [] } },
+        },
+      });
+      try {
+        await expect(accountsActions.exportCommunity()).rejects.toThrow(
+          "accountsActions.exportCommunity no community addresses to export",
+        );
+      } finally {
+        accountsStore.setState({ accounts });
+      }
+      await expect(accountsActions.exportCommunity([undefined as any])).rejects.toThrow(
+        "accountsActions.exportCommunity invalid communityAddress 'undefined'",
+      );
+      await expect(
+        accountsActions.exportCommunity("bad-options.eth", "bad" as any),
+      ).rejects.toThrow(
+        "accountsActions.exportCommunity invalid exportCommunityOptions argument 'bad'",
+      );
+    });
+
+    test("exportCommunity requires community.export", async () => {
+      const createCommunity = BasePkc.prototype.createCommunity;
+      BasePkc.prototype.createCommunity = async () => ({ address: "no-export.eth" }) as any;
+
+      try {
+        await expect(accountsActions.exportCommunity("no-export.eth")).rejects.toThrow(
+          "accountsActions.exportCommunity community.export missing for communityAddress 'no-export.eth'",
+        );
+      } finally {
+        BasePkc.prototype.createCommunity = createCommunity;
+      }
     });
 
     test("publishCommunityEdit uses local owner state when pkc communities list is stale", async () => {

--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -722,6 +722,27 @@ describe("accounts-actions", () => {
       }
     });
 
+    test("exportCommunity keeps the requested communityAddress when export metadata conflicts", async () => {
+      const originalExport = BaseCommunity.prototype.export;
+      BaseCommunity.prototype.export = async function (options: any) {
+        const result = await originalExport.call(this, options);
+        return { ...result, communityAddress: "wrong-export-address.eth" };
+      };
+
+      try {
+        const communityExports = await accountsActions.exportCommunity("requested-export.eth");
+
+        expect(communityExports).toEqual([
+          {
+            communityAddress: "requested-export.eth",
+            exportId: "requested-export.eth export 1",
+          },
+        ]);
+      } finally {
+        BaseCommunity.prototype.export = originalExport;
+      }
+    });
+
     test("exportCommunity defaults to account pkc communities", async () => {
       await act(async () => {
         await accountsActions.createCommunity({ title: "Export default list" });

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -814,8 +814,8 @@ export const exportCommunity = async (
   );
   log("accountsActions.exportCommunity", {
     communityAddresses,
-    exportCommunityOptions,
-    communityExports,
+    includePrivateKey: exportCommunityOptions.includePrivateKey === true,
+    communityExportCount: communityExports.length,
   });
   return communityExports;
 };

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -20,12 +20,15 @@ import {
   PublishCommentModerationOptions,
   PublishCommunityEditOptions,
   CreateCommunityOptions,
+  ExportCommunityOptions,
+  CommunityExport,
   Communities,
   AccountComment,
 } from "../../types";
 import * as accountsActionsInternal from "./accounts-actions-internal";
 import {
   backfillPublicationCommunityAddress,
+  createPkcCommunity,
   createPkcCommunityEdit,
   getPkcCommunityAddresses,
   normalizeCommunityEditOptionsForPkc,
@@ -747,6 +750,74 @@ export const exportAccount = async (accountName?: string) => {
   const exportedAccountJson = await accountsDatabase.getExportedAccountJson(account.id);
   log("accountsActions.exportAccount", { exportedAccountJson });
   return exportedAccountJson;
+};
+
+const getCommunityAddressesToExport = (
+  communityAddressOrAddresses: string | string[] | undefined,
+  account: Account,
+) => {
+  if (Array.isArray(communityAddressOrAddresses)) {
+    return communityAddressOrAddresses;
+  }
+  if (communityAddressOrAddresses) {
+    return [communityAddressOrAddresses];
+  }
+  return getPkcCommunityAddresses(account.pkc);
+};
+
+export const exportCommunity = async (
+  communityAddressOrAddresses?: string | string[],
+  exportCommunityOptions: ExportCommunityOptions = {},
+  accountName?: string,
+): Promise<CommunityExport[]> => {
+  const { accounts, accountNamesToAccountIds, activeAccountId } = accountsStore.getState();
+  assert(
+    accounts && accountNamesToAccountIds && activeAccountId,
+    `can't use accountsStore.accountsActions before initialized`,
+  );
+  assert(
+    !exportCommunityOptions || typeof exportCommunityOptions === "object",
+    `accountsActions.exportCommunity invalid exportCommunityOptions argument '${exportCommunityOptions}'`,
+  );
+  let account = accounts[activeAccountId];
+  if (accountName) {
+    const accountId = accountNamesToAccountIds[accountName];
+    account = accounts[accountId];
+  }
+  assert(
+    account?.id,
+    `accountsActions.exportCommunity account.id '${account?.id}' doesn't exist, activeAccountId '${activeAccountId}' accountName '${accountName}'`,
+  );
+
+  const communityAddresses = getCommunityAddressesToExport(communityAddressOrAddresses, account);
+  assert(
+    communityAddresses.length > 0,
+    `accountsActions.exportCommunity no community addresses to export`,
+  );
+  for (const communityAddress of communityAddresses) {
+    assert(
+      communityAddress && typeof communityAddress === "string",
+      `accountsActions.exportCommunity invalid communityAddress '${communityAddress}'`,
+    );
+  }
+
+  const communityExports = await Promise.all(
+    [...new Set(communityAddresses)].map(async (communityAddress) => {
+      const community = await createPkcCommunity(account.pkc, { address: communityAddress });
+      assert(
+        typeof community?.export === "function",
+        `accountsActions.exportCommunity community.export missing for communityAddress '${communityAddress}'`,
+      );
+      const exportedCommunity = await community.export(exportCommunityOptions);
+      return { communityAddress, ...exportedCommunity };
+    }),
+  );
+  log("accountsActions.exportCommunity", {
+    communityAddresses,
+    exportCommunityOptions,
+    communityExports,
+  });
+  return communityExports;
 };
 
 export const subscribe = async (communityAddress: string, accountName?: string) => {

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -809,7 +809,7 @@ export const exportCommunity = async (
         `accountsActions.exportCommunity community.export missing for communityAddress '${communityAddress}'`,
       );
       const exportedCommunity = await community.export(exportCommunityOptions);
-      return { communityAddress, ...exportedCommunity };
+      return { ...exportedCommunity, communityAddress };
     }),
   );
   log("accountsActions.exportCommunity", {

--- a/src/types.ts
+++ b/src/types.ts
@@ -591,7 +591,12 @@ export type PublishVoteOptions = { [key: string]: any };
 export type PublishCommentEditOptions = { [key: string]: any };
 export type PublishCommentModerationOptions = { [key: string]: any };
 export type PublishCommunityEditOptions = { [key: string]: any };
-export type ExportCommunityOptions = { [key: string]: any };
+export interface ExportCommunityOptions {
+  includePrivateKey?: boolean;
+  exportPath?: string;
+  signal?: AbortSignal;
+  [key: string]: unknown;
+}
 export type Challenge = { [key: string]: any };
 export type ChallengeVerification = { [key: string]: any };
 export type CreateCommentOptions = { [key: string]: any };
@@ -603,7 +608,16 @@ export type CommentEdit = { [key: string]: any };
 export type CommentModeration = { [key: string]: any };
 export type CommunityEdit = { [key: string]: any };
 export type Community = { [key: string]: any };
-export type CommunityExport = { communityAddress: string; exportId: string; [key: string]: any };
+export type CommunityExport = {
+  communityAddress: string;
+  exportId: string;
+  name?: string;
+  publicKey?: string;
+  includePrivateKey?: boolean;
+  progress?: number;
+  url?: string;
+  [key: string]: unknown;
+};
 export type CommunityStats = { [key: string]: any };
 export type Notification = { [key: string]: any };
 export type Nft = { [key: string]: any };

--- a/src/types.ts
+++ b/src/types.ts
@@ -464,6 +464,19 @@ export interface UseCreateCommunityResult extends Result {
   createCommunity(): Promise<void>;
 }
 
+// useExportCommunity(options): result
+export interface UseExportCommunityOptions extends Options {
+  communityAddress?: string;
+  communityAddresses?: string[];
+  includePrivateKey?: boolean;
+  exportPath?: string;
+  signal?: AbortSignal;
+}
+export interface UseExportCommunityResult extends Result {
+  communityExports: CommunityExport[];
+  exportCommunity(): Promise<void>;
+}
+
 // useDeleteCommunity(options): result
 // export interface UseDeleteCommunityOptions extends Options {
 //   communityAddress?: string
@@ -578,6 +591,7 @@ export type PublishVoteOptions = { [key: string]: any };
 export type PublishCommentEditOptions = { [key: string]: any };
 export type PublishCommentModerationOptions = { [key: string]: any };
 export type PublishCommunityEditOptions = { [key: string]: any };
+export type ExportCommunityOptions = { [key: string]: any };
 export type Challenge = { [key: string]: any };
 export type ChallengeVerification = { [key: string]: any };
 export type CreateCommentOptions = { [key: string]: any };
@@ -589,6 +603,7 @@ export type CommentEdit = { [key: string]: any };
 export type CommentModeration = { [key: string]: any };
 export type CommunityEdit = { [key: string]: any };
 export type Community = { [key: string]: any };
+export type CommunityExport = { communityAddress: string; exportId: string; [key: string]: any };
 export type CommunityStats = { [key: string]: any };
 export type Notification = { [key: string]: any };
 export type Nft = { [key: string]: any };

--- a/yarn.lock
+++ b/yarn.lock
@@ -284,7 +284,7 @@ __metadata:
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.8"
-    "@pkcprotocol/pkc-js": "npm:0.0.38"
+    "@pkcprotocol/pkc-js": "npm:0.0.41"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
@@ -3168,9 +3168,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkcprotocol/pkc-js@npm:0.0.38":
-  version: 0.0.38
-  resolution: "@pkcprotocol/pkc-js@npm:0.0.38"
+"@pkcprotocol/pkc-js@npm:0.0.41":
+  version: 0.0.41
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.41"
   dependencies:
     "@enhances/with-resolvers": "npm:0.0.5"
     "@helia/block-brokers": "npm:5.2.4"
@@ -3219,7 +3219,7 @@ __metadata:
     typestub-ipfs-only-hash: "npm:4.0.0"
     uuid: "npm:13.0.0"
     zod: "npm:4.3.6"
-  checksum: 10c0/97f94ca73911a6acc58658c3e6356f17ebf2388f88965052da8176759b297030a0933c874ab287c31e32d717bff7709a76df91d438b8bd010801be6a25fd873b
+  checksum: 10c0/4ecff61239f79e84665b2a44507b067711f9a6d04a766e651bbd5f95d663624b8573c6449d3959b80851efcfa2635b8139782bedcf0f2dffdd76418a05e6259b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `@pkcprotocol/pkc-js` to `0.0.41`.
- Add `accountsActions.exportCommunity()` and `useExportCommunity()` for one, many, or all account communities.
- Update the pkc-js mock, public exports, types, README, and generated LLM context.

## Verification
- `yarn build`
- `yarn test`
- `yarn test:coverage`

Note: `node scripts/verify-hooks-stores-coverage.mjs` still reports existing repo-wide hooks/stores coverage gaps outside this feature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches account actions and optional private-key export via upgraded pkc-js; well-covered by tests but desktop/export paths warrant careful review.
> 
> **Overview**
> Adds **desktop community export** end-to-end: bumps `@pkcprotocol/pkc-js` to **0.0.41**, implements `accountsActions.exportCommunity()` (single address, list, or default to all PKC-listed communities; concurrent exports; optional `includePrivateKey` / `exportPath`), and exposes **`useExportCommunity()`** with `state` / `error` / `communityExports` and context-aware clearing when the account or export targets change.
> 
> Public API updates include new `ExportCommunityOptions` / `CommunityExport` types, package exports, README and LLM docs recipes, and mock `Community.export` for tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14b96b0ed40dbe409e32fba3b0ed4c0a9e85bab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `useExportCommunity` hook enabling users to export single, multiple, or all communities associated with their account
  * Desktop-only export functionality with built-in state and error handling

* **Documentation**
  * Updated API reference with new export hook documentation
  * Added export communities recipe with practical usage examples

* **Chores**
  * Updated `@pkcprotocol/pkc-js` dependency to v0.0.41

<!-- end of auto-generated comment: release notes by coderabbit.ai -->