### PR TITLE
chore(release): prepare 0.1.24

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.23",
+  "version": "0.1.24",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.8",
-    "@pkcprotocol/pkc-js": "0.0.57",
+    "@pkcprotocol/pkc-js": "0.0.59",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,7 +319,7 @@ __metadata:
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.8"
-    "@pkcprotocol/pkc-js": "npm:0.0.57"
+    "@pkcprotocol/pkc-js": "npm:0.0.59"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
@@ -3536,9 +3536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkcprotocol/pkc-js@npm:0.0.57":
-  version: 0.0.57
-  resolution: "@pkcprotocol/pkc-js@npm:0.0.57"
+"@pkcprotocol/pkc-js@npm:0.0.59":
+  version: 0.0.59
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.59"
   dependencies:
     "@enhances/with-resolvers": "npm:0.0.5"
     "@helia/block-brokers": "npm:5.2.4"
@@ -3599,7 +3599,7 @@ __metadata:
     uuid: "npm:13.0.0"
     ws: "npm:8.20.0"
     zod: "npm:4.3.6"
-  checksum: 10c0/d0bacdeaf11315d2c292e5af4d3d15d94c9fd2b560cf32497df44b78d3fe8a7ed77b645b45b919bb0e7b7c6ddd859bcba98ff5f6c6f8721832b4d35acf970e8b
+  checksum: 10c0/5c7a701c131af7e44789f54539b7844f583025ccd4034a3f75ae72e6e69da138038db62062fb7e6fb031162368bbfbd54edb41b2d74682d0d8e40e9d497e984c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- bump @pkcprotocol/pkc-js from 0.0.57 to 0.0.59
- bump @bitsocial/bitsocial-react-hooks package version to 0.1.24
- refresh the Yarn lockfile for the new pkc-js resolution

## Verification
- yarn prettier
- yarn build
- yarn test
- yarn knip
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release with a dependency patch bump; no application code changes in the diff.
> 
> **Overview**
> Prepares **0.1.24** of `@bitsocial/bitsocial-react-hooks` by bumping the published package version and upgrading the core protocol dependency **`@pkcprotocol/pkc-js`** from **0.0.57** to **0.0.59**.
> 
> The lockfile is updated so installs resolve the new `pkc-js` tarball and checksum; there are no changes to library source in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a41d2afa0fffe0f22778ba3f6651edd6bdd0d31a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped the app version to `0.1.24`.
  * Updated a runtime dependency to a newer patch release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->