### PR TITLE
chore(release): prepare 0.1.26

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.25",
+  "version": "0.1.26",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.8",
-    "@pkcprotocol/pkc-js": "0.0.59",
+    "@pkcprotocol/pkc-js": "0.0.62",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,7 +319,7 @@ __metadata:
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.8"
-    "@pkcprotocol/pkc-js": "npm:0.0.59"
+    "@pkcprotocol/pkc-js": "npm:0.0.62"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
@@ -3536,9 +3536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkcprotocol/pkc-js@npm:0.0.59":
-  version: 0.0.59
-  resolution: "@pkcprotocol/pkc-js@npm:0.0.59"
+"@pkcprotocol/pkc-js@npm:0.0.62":
+  version: 0.0.62
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.62"
   dependencies:
     "@enhances/with-resolvers": "npm:0.0.5"
     "@helia/block-brokers": "npm:5.2.4"
@@ -3599,7 +3599,7 @@ __metadata:
     uuid: "npm:13.0.0"
     ws: "npm:8.20.0"
     zod: "npm:4.3.6"
-  checksum: 10c0/5c7a701c131af7e44789f54539b7844f583025ccd4034a3f75ae72e6e69da138038db62062fb7e6fb031162368bbfbd54edb41b2d74682d0d8e40e9d497e984c
+  checksum: 10c0/c55f2b5e3d52a4716124228bf9fc51cb949aff44a8d9404b4bd870367ef5c27d4cc98a2521054f2d8d008fc90977ac9a74d44e6cc619d4c4280c12128dabce9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- bump package version to 0.1.26
- upgrade @pkcprotocol/pkc-js from 0.0.59 to 0.0.62
- refresh yarn.lock

## Verification
- yarn install
- yarn build
- yarn test:coverage:hooks-stores (unit tests passed; coverage verifier reported existing hooks/stores baseline below 100%)
- yarn prettier
- git diff --check
- code-quality-review advisory: no high-confidence findings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> No library code changes, but the pkc-js bump can alter protocol/network behavior for all consumers of this release.
> 
> **Overview**
> Prepares **0.1.26** by bumping the published package version and upgrading the **`@pkcprotocol/pkc-js`** dependency from **0.0.59** to **0.0.62**, with **`yarn.lock`** updated to match.
> 
> There are **no source or hook changes** in this diff—only release metadata and the protocol client pin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66fdcddfc780352030452002ba9bb632deb3bf1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app version to `0.1.26`.
  * Upgraded a bundled dependency to a newer release for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->