### PR TITLE
chore(release): prepare 0.1.27

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.26",
+  "version": "0.1.27",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.8",
-    "@pkcprotocol/pkc-js": "0.0.62",
+    "@pkcprotocol/pkc-js": "0.0.65",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,7 +319,7 @@ __metadata:
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.8"
-    "@pkcprotocol/pkc-js": "npm:0.0.62"
+    "@pkcprotocol/pkc-js": "npm:0.0.65"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
@@ -3536,9 +3536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkcprotocol/pkc-js@npm:0.0.62":
-  version: 0.0.62
-  resolution: "@pkcprotocol/pkc-js@npm:0.0.62"
+"@pkcprotocol/pkc-js@npm:0.0.65":
+  version: 0.0.65
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.65"
   dependencies:
     "@enhances/with-resolvers": "npm:0.0.5"
     "@helia/block-brokers": "npm:5.2.4"
@@ -3585,7 +3585,7 @@ __metadata:
     p-timeout: "npm:7.0.1"
     probe-image-size: "npm:7.2.3"
     quick-lru: "npm:5.1.1"
-    remeda: "npm:1.57.0"
+    remeda: "npm:2.39.0"
     retry: "npm:0.13.1"
     rpc-websockets: "npm:9.3.8"
     safe-stable-stringify: "npm:2.4.3"
@@ -3599,7 +3599,7 @@ __metadata:
     uuid: "npm:13.0.0"
     ws: "npm:8.20.0"
     zod: "npm:4.3.6"
-  checksum: 10c0/c55f2b5e3d52a4716124228bf9fc51cb949aff44a8d9404b4bd870367ef5c27d4cc98a2521054f2d8d008fc90977ac9a74d44e6cc619d4c4280c12128dabce9a
+  checksum: 10c0/5cb8f6545ea53d48a7092c644a968ccfc1fcc07894245d5bb20a94b8fdd6735c8232546de9706cc207e5d69cca912f780ca539e1ef6cac21969d00a400e4a3d4
   languageName: node
   linkType: hard
 
@@ -11416,10 +11416,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"remeda@npm:1.57.0":
-  version: 1.57.0
-  resolution: "remeda@npm:1.57.0"
-  checksum: 10c0/d5b455ee854ddf83dbf30fff279edf6c1e5a89885bfdf89a383ec003a9ecf6076be8d9d784d8ad0689bc129ba7480b308ae0cd8acfc85666d7df6d441dcca9ab
+"remeda@npm:2.39.0":
+  version: 2.39.0
+  resolution: "remeda@npm:2.39.0"
+  checksum: 10c0/5891871c93b47c501937d6e4a1c05d0b199b4402a8eb3a7a08653e81acc4ce45ae3cff4c90785d867f5e9b5f75e27b5120f0240e8ce490fbf2ab8c48013cc8af
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `@pkcprotocol/pkc-js` from `0.0.62` to `0.0.65`
- Bump package version to `0.1.27`

## Test plan
- [x] `yarn build`
- [x] `yarn test` (1122 passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior of React hooks depends on pkc-js; a minor protocol client bump can change runtime behavior even without local code edits, though tests reportedly pass.
> 
> **Overview**
> Prepares **0.1.27** by bumping the published package version and upgrading the core protocol client dependency **`@pkcprotocol/pkc-js`** from `0.0.62` to `0.0.65`. The lockfile is refreshed accordingly (including **`remeda`** moving to `2.39.0` as a transitive dependency of `pkc-js`).
> 
> There are **no application source changes** in this diff—only version and dependency metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d58fd3b36175839855ce735e24b1fe69e17cf0b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version to `0.1.27`.
  * Bumped a dependency to a newer compatible release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->