### PR TITLE
chore(release): prepare 0.1.28

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.27",
+  "version": "0.1.28",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@bitsocial/bso-resolver": "0.0.8",
-    "@pkcprotocol/pkc-js": "0.0.65",
+    "@pkcprotocol/pkc-js": "0.0.68",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",
     "ethers": "5.8.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -319,7 +319,7 @@ __metadata:
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
     "@bitsocial/bso-resolver": "npm:0.0.8"
-    "@pkcprotocol/pkc-js": "npm:0.0.65"
+    "@pkcprotocol/pkc-js": "npm:0.0.68"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
     "@testing-library/react": "npm:16.3.2"
@@ -3536,9 +3536,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkcprotocol/pkc-js@npm:0.0.65":
-  version: 0.0.65
-  resolution: "@pkcprotocol/pkc-js@npm:0.0.65"
+"@pkcprotocol/pkc-js@npm:0.0.68":
+  version: 0.0.68
+  resolution: "@pkcprotocol/pkc-js@npm:0.0.68"
   dependencies:
     "@enhances/with-resolvers": "npm:0.0.5"
     "@helia/block-brokers": "npm:5.2.4"
@@ -3599,7 +3599,7 @@ __metadata:
     uuid: "npm:13.0.0"
     ws: "npm:8.20.0"
     zod: "npm:4.3.6"
-  checksum: 10c0/5cb8f6545ea53d48a7092c644a968ccfc1fcc07894245d5bb20a94b8fdd6735c8232546de9706cc207e5d69cca912f780ca539e1ef6cac21969d00a400e4a3d4
+  checksum: 10c0/e2922b0ecdcda37bec50e646c4547fb4c75932dd00659ffab63588d5551c5841caa47b95b534cdd925d72e5b7d64a641d473dd8962247f9ad1a63bcd80086bf8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade `@pkcprotocol/pkc-js` from `0.0.65` to `0.0.68`
- bump `@bitsocial/bitsocial-react-hooks` to `0.1.28`

## Verification

- `yarn prettier`
- `yarn build`
- `yarn test` (1,122 passed, 6 skipped)
- `yarn knip`
- `git diff --check`

The advisory `yarn test:coverage:hooks-stores` verifier reports the repository's existing sub-100% hooks/stores coverage baseline; the complete coverage test suite itself passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> `pkc-js` is a core runtime dependency for PKC client behavior; a three-minor-version bump can change networking or API semantics even though this repo’s wrapper code is unchanged.
> 
> **Overview**
> Prepares a patch release of `@bitsocial/bitsocial-react-hooks` at **0.1.28** with no application source edits in this diff.
> 
> The only functional dependency change is bumping **`@pkcprotocol/pkc-js`** from `0.0.65` to `0.0.68`; `yarn.lock` is updated to match (including the new package checksum). Consumers of this library inherit the updated PKC client behavior through the existing lazy adapter in `src/lib/pkc-js`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3663aec02a70729acf69157d3f857e285ebf9340. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application release version to 0.1.28.
  * Upgraded the PKC JavaScript integration to version 0.0.68.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->