### PR TITLE
chore(release): prepare 0.1.30

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.29",
+  "version": "0.1.30",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",
@@ -47,7 +47,7 @@
     "changelog:release-notes": "node scripts/changelog-release-notes.mjs"
   },
   "dependencies": {
-    "@bitsocial/bso-resolver": "0.0.8",
+    "@bitsocial/bso-resolver": "0.0.10",
     "@pkcprotocol/pkc-js": "0.0.71",
     "@pkcprotocol/pkc-logger": "0.1.0",
     "assert": "2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -318,7 +318,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@bitsocial/bitsocial-react-hooks@workspace:."
   dependencies:
-    "@bitsocial/bso-resolver": "npm:0.0.8"
+    "@bitsocial/bso-resolver": "npm:0.0.10"
     "@pkcprotocol/pkc-js": "npm:0.0.71"
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
     "@testing-library/dom": "npm:10.4.1"
@@ -370,13 +370,13 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@bitsocial/bso-resolver@npm:0.0.8":
-  version: 0.0.8
-  resolution: "@bitsocial/bso-resolver@npm:0.0.8"
+"@bitsocial/bso-resolver@npm:0.0.10":
+  version: 0.0.10
+  resolution: "@bitsocial/bso-resolver@npm:0.0.10"
   dependencies:
     "@pkcprotocol/pkc-logger": "npm:0.1.0"
-    viem: "npm:2.48.1"
-  checksum: 10c0/0acb033cac4f8860323e154a5a53b95e9d107326e78bc9febd36091cd96dc2c095b31996d594fba9d676c132305c5504d5b7e1b3e5af1f78e2c372f1eebc2f7a
+    viem: "npm:2.55.1"
+  checksum: 10c0/6dd612cb374fadb4f23d37eb6f48292032efa64867871a3d2f81b0c1a4d9a4bdb6463afb0d737ec60a78a39505d92aaf42586812356e31e21b49012daf8fd55c
   languageName: node
   linkType: hard
 
@@ -10346,9 +10346,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ox@npm:0.14.17":
-  version: 0.14.17
-  resolution: "ox@npm:0.14.17"
+"ox@npm:0.14.30":
+  version: 0.14.30
+  resolution: "ox@npm:0.14.30"
   dependencies:
     "@adraffy/ens-normalize": "npm:^1.11.0"
     "@noble/ciphers": "npm:^1.3.0"
@@ -10363,7 +10363,7 @@ __metadata:
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/a4632918d89db20e7265dff96dec3786046e2ec99a42659badd300b7b24678348f505fd57e651c3a814a150d905f512a23a037f15757eae41db601d25fa7b10c
+  checksum: 10c0/dfefa9218269103b3da3686c4da62849aef15e4347fd21f898fa113d9b4c2b86afab7c662c94d58206257736202647ce96249405c021c4a233712ac34fa3cc1b
   languageName: node
   linkType: hard
 
@@ -13038,9 +13038,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"viem@npm:2.48.1":
-  version: 2.48.1
-  resolution: "viem@npm:2.48.1"
+"viem@npm:2.55.1":
+  version: 2.55.1
+  resolution: "viem@npm:2.55.1"
   dependencies:
     "@noble/curves": "npm:1.9.1"
     "@noble/hashes": "npm:1.8.0"
@@ -13048,14 +13048,14 @@ __metadata:
     "@scure/bip39": "npm:1.6.0"
     abitype: "npm:1.2.3"
     isows: "npm:1.0.7"
-    ox: "npm:0.14.17"
-    ws: "npm:8.18.3"
+    ox: "npm:0.14.30"
+    ws: "npm:8.21.0"
   peerDependencies:
     typescript: ">=5.0.4"
   peerDependenciesMeta:
     typescript:
       optional: true
-  checksum: 10c0/222ad600cee6f9887228e2a9a8bc9d11315cb8a68cef6e271de4aee75be087be33544d3f1c7483d8a5c93c1964bbd4298fc6b36bfbcd3b7f1a66bda0de82d841
+  checksum: 10c0/4747450c511604dc2280b94b6a6eab53638058a559531f7707d31f21de51670449530f9ebc2fbc06d961b8b5a6cfadb920683e701058adc8996619b012bbc56d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade `@bitsocial/bso-resolver` from 0.0.8 to 0.0.10
- Bump package version to 0.1.30 for npm/GitHub release

## Test plan
- [x] `yarn build`
- [x] `yarn test`
- [ ] CI passes and publishes `@bitsocial/bitsocial-react-hooks@0.1.30` on merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version and dependency-only release with no src changes; main exposure is indirect behavior from bso-resolver/viem upgrades in name-resolution paths.
> 
> **Overview**
> Prepares **0.1.30** for publish by bumping the package version and upgrading **`@bitsocial/bso-resolver`** from `0.0.8` to `0.0.10`. There are no application source changes—only `package.json` and `yarn.lock`.
> 
> The lockfile refresh pulls in newer transitive deps for the resolver (notably **`viem`** `2.48.1` → `2.55.1`, plus updated **`ox`** and **`ws`** entries tied to that tree). Consumers of hooks that resolve author names via `BsoResolver` in `pkc-compat` inherit whatever behavior fixes ship in resolver `0.0.10`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f650101355bcf89044626d5507c417c7f574f971. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 0.1.30.
  * Updated the resolver component to its latest supported version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->