### PR TITLE
feat(communities): expose sync lifecycle state

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ useValidateComment({comment: Comment, validateReplies?: boolean}): {valid: boole
 #### Communities Hooks
 
 ```
-useCommunity({community: {name?: string, publicKey?: string}, onlyIfCached?: boolean}): Community
+useCommunity({community: {name?: string, publicKey?: string}, onlyIfCached?: boolean}): Community & {syncState: "initializing" | "loading" | "retrying" | "succeeded" | "failed" | "stopped", hasCachedData: boolean, lastFetchAttemptAt: number | undefined, lastSuccessfulFetchAt: number | undefined}
 useCommunities({communities?: CommunityIdentifier[], onlyIfCached?: boolean}): {communities: Communities[]}
 useCommunityStats({community: {name?: string, publicKey?: string}, onlyIfCached?: boolean}): CommunityStats
 useResolvedCommunityAddress({communityAddress: string, cache: boolean}): {resolvedAddress: string | undefined} // use {cache: false} when checking the user's own community address
@@ -138,6 +138,13 @@ useResolvedCommunityAddress({communityAddress: string, cache: boolean}): {resolv
 Pass `{ publicKey, name }` when you have both so `pkc-js` can fetch through the public key and resolve the name in the background. `communityAddress`, `communityAddresses`, and `communityRefs` are no longer accepted by these hooks.
 
 `useCommunity` only exposes community error events that are not superseded by a later `update` event. Transient fetch errors are delayed briefly before surfacing through `error` or `errors`.
+
+`useCommunity().state` remains `succeeded` when cached community data is available, even
+while a refresh is running. Use `syncState` for the current refresh lifecycle:
+`loading` covers active name, IPNS, and IPFS work, while `retrying` means a transient
+failure is being retried. `lastFetchAttemptAt` and `lastSuccessfulFetchAt` are Unix
+timestamps in seconds. A successful fetch only proves that a valid community record was
+reachable; it does not prove that the community operator is currently online.
 
 #### Authors Hooks
 
@@ -409,6 +416,12 @@ const { authorComments, lastCommentCid, hasMore, loadMore } = useAuthorComments(
 
 ```jsx
 const community = useCommunity({ community: { name: communityAddress, publicKey: communityPublicKey } });
+const {
+  syncState,
+  hasCachedData,
+  lastFetchAttemptAt,
+  lastSuccessfulFetchAt,
+} = community;
 const communityStats = useCommunityStats({
   community: { name: communityAddress, publicKey: communityPublicKey },
 });

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -159,7 +159,7 @@ useValidateComment({comment: Comment, validateReplies?: boolean}): {valid: boole
 #### Communities Hooks
 
 ```
-useCommunity({community: {name?: string, publicKey?: string}, onlyIfCached?: boolean}): Community
+useCommunity({community: {name?: string, publicKey?: string}, onlyIfCached?: boolean}): Community & {syncState: "initializing" | "loading" | "retrying" | "succeeded" | "failed" | "stopped", hasCachedData: boolean, lastFetchAttemptAt: number | undefined, lastSuccessfulFetchAt: number | undefined}
 useCommunities({communities?: CommunityIdentifier[], onlyIfCached?: boolean}): {communities: Communities[]}
 useCommunityStats({community: {name?: string, publicKey?: string}, onlyIfCached?: boolean}): CommunityStats
 useResolvedCommunityAddress({communityAddress: string, cache: boolean}): {resolvedAddress: string | undefined} // use {cache: false} when checking the user's own community address
@@ -168,6 +168,13 @@ useResolvedCommunityAddress({communityAddress: string, cache: boolean}): {resolv
 Pass `{ publicKey, name }` when you have both so `pkc-js` can fetch through the public key and resolve the name in the background. `communityAddress`, `communityAddresses`, and `communityRefs` are no longer accepted by these hooks.
 
 `useCommunity` only exposes community error events that are not superseded by a later `update` event. Transient fetch errors are delayed briefly before surfacing through `error` or `errors`.
+
+`useCommunity().state` remains `succeeded` when cached community data is available, even
+while a refresh is running. Use `syncState` for the current refresh lifecycle:
+`loading` covers active name, IPNS, and IPFS work, while `retrying` means a transient
+failure is being retried. `lastFetchAttemptAt` and `lastSuccessfulFetchAt` are Unix
+timestamps in seconds. A successful fetch only proves that a valid community record was
+reachable; it does not prove that the community operator is currently online.
 
 #### Authors Hooks
 
@@ -439,6 +446,12 @@ const { authorComments, lastCommentCid, hasMore, loadMore } = useAuthorComments(
 
 ```jsx
 const community = useCommunity({ community: { name: communityAddress, publicKey: communityPublicKey } });
+const {
+  syncState,
+  hasCachedData,
+  lastFetchAttemptAt,
+  lastSuccessfulFetchAt,
+} = community;
 const communityStats = useCommunityStats({
   community: { name: communityAddress, publicKey: communityPublicKey },
 });
@@ -3181,7 +3194,11 @@ Avoid GitHub MCP and browser MCP servers for this project because they add signi
 Source: https://github.com/bitsocialnet/bitsocial-react-hooks/blob/master/CHANGELOG.md
 
 ```markdown
-## [0.1.28](https://github.com/bitsocialnet/bitsocial-react-hooks/compare/v0.1.27...v0.1.28) (2026-07-10)
+## [0.1.30](https://github.com/bitsocialnet/bitsocial-react-hooks/compare/v0.1.29...v0.1.30) (2026-07-14)
+
+
+
+## [0.1.29](https://github.com/bitsocialnet/bitsocial-react-hooks/compare/v0.1.28...v0.1.29) (2026-07-14)
 
 
 

--- a/src/hooks/communities.test.ts
+++ b/src/hooks/communities.test.ts
@@ -152,6 +152,10 @@ describe("communities", () => {
       testUtils.createWaitFor(rendered);
 
       rendered.rerender({ community: { name: "community address 1" }, onlyIfCached: true });
+      expect(rendered.result.current.syncState).toBe("stopped");
+      expect(rendered.result.current.hasCachedData).toBe(false);
+      expect(rendered.result.current.lastFetchAttemptAt).toBeUndefined();
+      expect(rendered.result.current.lastSuccessfulFetchAt).toBeUndefined();
       // TODO: find better way to wait
       await new Promise((r) => setTimeout(r, 20));
       // community not added to store
@@ -240,21 +244,71 @@ describe("communities", () => {
       );
     });
 
-    test("has updating state", async () => {
-      const rendered = renderHook<any, any>((communityAddress) =>
-        useCommunity({ community: toCommunity(communityAddress) }),
-      );
-      const waitFor = testUtils.createWaitFor(rendered);
-      rendered.rerender("community address");
+    test("exposes community sync lifecycle separately from cached data state", async () => {
+      const communityUpdate = Community.prototype.update;
+      const updatingCommunities: Community[] = [];
+      let now = 1_800_000_000_000;
+      const nowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+      Community.prototype.update = async function () {
+        updatingCommunities.push(this);
+      };
 
-      await waitFor(
-        () =>
-          rendered.result.current.state === "fetching-ipns" ||
-          rendered.result.current.state === "succeeded",
-      );
+      try {
+        const rendered = renderHook<any, any>((communityAddress) =>
+          useCommunity({ community: toCommunity(communityAddress) }),
+        );
+        const waitFor = testUtils.createWaitFor(rendered);
+        rendered.rerender("community address");
 
-      await waitFor(() => rendered.result.current.state === "succeeded");
-      expect(rendered.result.current.state).toBe("succeeded");
+        expect(rendered.result.current.syncState).toBe("initializing");
+        expect(rendered.result.current.hasCachedData).toBe(false);
+        await waitFor(() => updatingCommunities.length > 0);
+        expect(rendered.result.current.lastFetchAttemptAt).toBeUndefined();
+
+        now += 1_000;
+        updatingCommunities[0].emit("updatingstatechange", "fetching-ipns");
+        await waitFor(() => rendered.result.current.syncState === "loading");
+        expect(rendered.result.current.lastFetchAttemptAt).toBe(1_800_000_001);
+
+        now += 1_000;
+        updatingCommunities[0].emit("updatingstatechange", "fetching-ipfs");
+        await act(async () => {});
+        expect(rendered.result.current.syncState).toBe("loading");
+        expect(rendered.result.current.lastFetchAttemptAt).toBe(1_800_000_001);
+
+        updatingCommunities[0].emit("updatingstatechange", "waiting-retry");
+        await waitFor(() => rendered.result.current.syncState === "retrying");
+
+        now += 1_000;
+        updatingCommunities[0].emit("updatingstatechange", "fetching-ipns");
+        await waitFor(() => rendered.result.current.syncState === "loading");
+        expect(rendered.result.current.lastFetchAttemptAt).toBe(1_800_000_003);
+
+        updatingCommunities[0].updatedAt = 1_799_999_000;
+        updatingCommunities[0].emit("update", updatingCommunities[0]);
+        now += 1_000;
+        updatingCommunities[0].emit("updatingstatechange", "succeeded");
+        await waitFor(() => rendered.result.current.syncState === "succeeded");
+        expect(rendered.result.current.state).toBe("succeeded");
+        expect(rendered.result.current.hasCachedData).toBe(true);
+        expect(rendered.result.current.lastSuccessfulFetchAt).toBe(1_800_000_004);
+
+        updatingCommunities[0].emit("updatingstatechange", "waiting-retry");
+        await waitFor(() => rendered.result.current.syncState === "retrying");
+        expect(rendered.result.current.state).toBe("succeeded");
+
+        updatingCommunities[0].emit("updatingstatechange", "publishing-ipns");
+        await waitFor(() => rendered.result.current.syncState === "loading");
+
+        updatingCommunities[0].emit("updatingstatechange", "stopped");
+        await waitFor(() => rendered.result.current.syncState === "stopped");
+
+        updatingCommunities[0].emit("updatingstatechange", "failed");
+        await waitFor(() => rendered.result.current.syncState === "failed");
+      } finally {
+        Community.prototype.update = communityUpdate;
+        nowSpy.mockRestore();
+      }
     });
 
     test("overlays local community edit summary from the active account", async () => {
@@ -379,6 +433,7 @@ describe("communities", () => {
       expect(rendered.result.current.error.message).toBe("pkc.createCommunity error");
       expect(rendered.result.current.errors[0].message).toBe("pkc.createCommunity error");
       expect(rendered.result.current.errors.length).toBe(1);
+      expect(rendered.result.current.syncState).toBe("failed");
 
       // restore mock
       PKC.prototype.createCommunity = createCommunity;

--- a/src/hooks/communities.ts
+++ b/src/hooks/communities.ts
@@ -80,6 +80,7 @@ export function useCommunity(options?: UseCommunityOptions): UseCommunityResult 
   const storedCommunity = useCommunitiesStore((state: any) => state.communities[communityKey]);
   const addCommunityToStore = useCommunitiesStore((state: any) => state.addCommunityToStore);
   const errors = useCommunitiesStore((state: any) => state.errors[communityKey]);
+  const syncStatus = useCommunitiesStore((state: any) => state.syncStatuses[communityKey]);
   const communityEditSummary = useAccountsStore((state: any) => {
     const accountEditsSummaries = state.accountsEditsSummaries[accountId] || {};
     const candidateCommunityKeys = [
@@ -169,10 +170,14 @@ export function useCommunity(options?: UseCommunityOptions): UseCommunityResult 
     () => ({
       ...mergedCommunity,
       state,
+      syncState: syncStatus?.syncState || (onlyIfCached ? "stopped" : "initializing"),
+      hasCachedData: typeof mergedCommunity?.updatedAt === "number",
+      lastFetchAttemptAt: syncStatus?.lastFetchAttemptAt,
+      lastSuccessfulFetchAt: syncStatus?.lastSuccessfulFetchAt,
       error: errors?.[errors.length - 1],
       errors: errors || [],
     }),
-    [mergedCommunity, communityKey, errors],
+    [mergedCommunity, communityKey, errors, onlyIfCached, syncStatus],
   );
 }
 

--- a/src/stores/communities/communities-store.test.ts
+++ b/src/stores/communities/communities-store.test.ts
@@ -701,6 +701,9 @@ describe("communities store", () => {
 
     expect(community.address).toBeDefined();
     expect(communitiesStore.getState().communities[community.address]?.title).toBe("created title");
+    communitiesStore.setState((state) => ({
+      errors: { ...state.errors, [community.address]: [new Error("stale error")] },
+    }));
 
     await act(async () => {
       await communitiesStore
@@ -715,6 +718,7 @@ describe("communities store", () => {
     });
 
     expect(communitiesStore.getState().communities[community.address]).toBeUndefined();
+    expect(communitiesStore.getState().errors[community.address]).toBeUndefined();
     expect(communitiesStore.getState().syncStatuses[community.address]).toBeUndefined();
   });
 

--- a/src/stores/communities/communities-store.test.ts
+++ b/src/stores/communities/communities-store.test.ts
@@ -31,6 +31,7 @@ describe("communities store", () => {
     const { result } = renderHook(() => communitiesStore.getState());
     expect(result.current.communities).toEqual({});
     expect(result.current.errors).toEqual({});
+    expect(result.current.syncStatuses).toEqual({});
     expect(typeof result.current.addCommunityToStore).toBe("function");
   });
 
@@ -367,6 +368,7 @@ describe("communities store", () => {
 
     expect(communitiesStore.getState().errors[address]).toHaveLength(1);
     expect(communitiesStore.getState().errors[address][0].message).toBe("create failed");
+    expect(communitiesStore.getState().syncStatuses[address]?.syncState).toBe("failed");
     mockAccount.pkc.createCommunity = createOrig;
   });
 
@@ -713,6 +715,7 @@ describe("communities store", () => {
     });
 
     expect(communitiesStore.getState().communities[community.address]).toBeUndefined();
+    expect(communitiesStore.getState().syncStatuses[community.address]).toBeUndefined();
   });
 
   test("clientsOnStateChange with chainTicker branch", async () => {
@@ -741,6 +744,37 @@ describe("communities store", () => {
     }));
     storedCb!();
     expect(communitiesStore.getState().communities[address]?.clients?.type?.ETH).toBeDefined();
+
+    (utils.default as any).clientsOnStateChange = origClientsOnStateChange;
+  });
+
+  test("clientsOnStateChange without chainTicker updates the client state", async () => {
+    const address = "client-state-address";
+    let storedCb: ((...args: any[]) => void) | null = null;
+
+    const utils = await import("../../lib/utils");
+    const origClientsOnStateChange = utils.default.clientsOnStateChange;
+    (utils.default as any).clientsOnStateChange = (_clients: any, cb: any) => {
+      storedCb = () => cb("fetching-ipns", "type", "url");
+    };
+
+    await act(async () => {
+      await communitiesStore.getState().addCommunityToStore(address, mockAccount);
+    });
+
+    communitiesStore.setState((state: any) => ({
+      communities: {
+        ...state.communities,
+        [address]: {
+          ...state.communities[address],
+          clients: { type: {} },
+        },
+      },
+    }));
+    storedCb!();
+    expect(communitiesStore.getState().communities[address]?.clients?.type?.url).toEqual({
+      state: "fetching-ipns",
+    });
 
     (utils.default as any).clientsOnStateChange = origClientsOnStateChange;
   });

--- a/src/stores/communities/communities-store.ts
+++ b/src/stores/communities/communities-store.ts
@@ -591,8 +591,11 @@ const communitiesStore = createStore<CommunitiesState>(
       setState((state: CommunitiesState) => {
         const syncStatuses = { ...state.syncStatuses };
         delete syncStatuses[communityAddress];
+        const errors = { ...state.errors };
+        delete errors[communityAddress];
         return {
           communities: { ...state.communities, [communityAddress]: undefined },
+          errors,
           syncStatuses,
         };
       });

--- a/src/stores/communities/communities-store.ts
+++ b/src/stores/communities/communities-store.ts
@@ -11,6 +11,7 @@ import {
   Communities,
   Account,
   CommunityIdentifier,
+  CommunitySyncState,
   CreateCommunityOptions,
 } from "../../types";
 import utils from "../../lib/utils";
@@ -44,6 +45,48 @@ const COMMUNITY_ERROR_UPDATE_GRACE_MS = 1000;
 const pendingCommunityErrorTimers: {
   [communityKey: string]: ReturnType<typeof setTimeout>[];
 } = {};
+
+interface CommunitySyncStatus {
+  syncState: CommunitySyncState;
+  lastFetchAttemptAt?: number;
+  lastSuccessfulFetchAt?: number;
+}
+
+const getNowSeconds = () => Math.floor(Date.now() / 1000);
+
+const normalizeCommunitySyncState = (updatingState: string): CommunitySyncState => {
+  if (updatingState === "waiting-retry") {
+    return "retrying";
+  }
+  if (updatingState === "succeeded" || updatingState === "failed" || updatingState === "stopped") {
+    return updatingState;
+  }
+  return "loading";
+};
+
+const updateCommunitySyncStatus = (
+  setState: Function,
+  communityKey: string,
+  syncState: CommunitySyncState,
+) => {
+  setState((state: CommunitiesState) => {
+    const previousStatus = state.syncStatuses[communityKey];
+    const timestamp = getNowSeconds();
+    const shouldRecordAttempt = syncState === "loading" && previousStatus?.syncState !== "loading";
+    return {
+      ...state,
+      syncStatuses: {
+        ...state.syncStatuses,
+        [communityKey]: {
+          ...previousStatus,
+          syncState,
+          ...(shouldRecordAttempt ? { lastFetchAttemptAt: timestamp } : undefined),
+          ...(syncState === "succeeded" ? { lastSuccessfulFetchAt: timestamp } : undefined),
+        },
+      },
+    };
+  });
+};
 
 const createCommunityWithLookupFallback = async (
   pkc: any,
@@ -170,6 +213,7 @@ const scheduleCommunityError = (setState: Function, communityKey: string, error:
 export type CommunitiesState = {
   communities: Communities;
   errors: { [communityAddress: string]: Error[] };
+  syncStatuses: { [communityAddress: string]: CommunitySyncStatus };
   addCommunityToStore: Function;
   refreshCommunity: Function;
   editCommunity: Function;
@@ -181,6 +225,7 @@ const communitiesStore = createStore<CommunitiesState>(
   (setState: Function, getState: Function) => ({
     communities: {},
     errors: {},
+    syncStatuses: {},
 
     async addCommunityToStore(
       communityAddressOrRef: string | CommunityIdentifier,
@@ -210,6 +255,7 @@ const communitiesStore = createStore<CommunitiesState>(
 
       // start trying to get community
       pkcGetCommunityPending[pendingKey] = true;
+      updateCommunitySyncStatus(setState, communityKey, "initializing");
       let errorGettingCommunity: any;
       try {
         // try to find community in owner communities
@@ -349,6 +395,11 @@ const communitiesStore = createStore<CommunitiesState>(
         });
 
         community.on("updatingstatechange", (updatingState: string) => {
+          updateCommunitySyncStatus(
+            setState,
+            communityKey,
+            normalizeCommunitySyncState(updatingState),
+          );
           setState((state: CommunitiesState) => ({
             communities: {
               ...state.communities,
@@ -390,6 +441,9 @@ const communitiesStore = createStore<CommunitiesState>(
 
         listeners.push(community);
         startCommunityUpdatePolling(community, { communityAddressOrRef, communityKey });
+      } catch (error) {
+        updateCommunitySyncStatus(setState, communityKey, "failed");
+        throw error;
       } finally {
         pkcGetCommunityPending[pendingKey] = false;
       }
@@ -534,9 +588,14 @@ const communitiesStore = createStore<CommunitiesState>(
       stopCommunityUpdatePolling(communityAddress);
       await communitiesDatabase.removeItem(communityAddress);
       log("communitiesStore.deleteCommunity", { communityAddress, community, account });
-      setState((state: any) => ({
-        communities: { ...state.communities, [communityAddress]: undefined },
-      }));
+      setState((state: CommunitiesState) => {
+        const syncStatuses = { ...state.syncStatuses };
+        delete syncStatuses[communityAddress];
+        return {
+          communities: { ...state.communities, [communityAddress]: undefined },
+          syncStatuses,
+        };
+      });
     },
   }),
 );

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,11 +199,24 @@ export interface UseEditedCommentResult extends Result {
 }
 
 // useCommunity(options): result
+export type CommunitySyncState =
+  | "initializing"
+  | "loading"
+  | "retrying"
+  | "succeeded"
+  | "failed"
+  | "stopped";
+
 export interface UseCommunityOptions extends Options {
   community?: CommunityIdentifier;
   onlyIfCached?: boolean;
 }
-export interface UseCommunityResult extends Result, Community {}
+export interface UseCommunityResult extends Result, Community {
+  syncState: CommunitySyncState;
+  hasCachedData: boolean;
+  lastFetchAttemptAt: number | undefined;
+  lastSuccessfulFetchAt: number | undefined;
+}
 
 // useCommunities(options): result
 export interface UseCommunitiesOptions extends Options {


### PR DESCRIPTION
## Summary

- preserve the existing cached-data `state` semantics
- expose normalized community synchronization state and lifecycle timestamps
- document and test loading, retrying, success, failure, and cached-data behavior

## Verification

- `yarn build`
- `yarn type-check`
- `yarn lint` (0 errors; existing warnings only)
- `yarn test` (1,123 passed, 6 skipped)
- focused community lifecycle tests and coverage

Closes #72

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and store fields with preserved `state` semantics; risk is mainly consumers misreading `state` vs `syncState` if they skip the docs.
> 
> **Overview**
> **`useCommunity`** now returns **`syncState`**, **`hasCachedData`**, **`lastFetchAttemptAt`**, and **`lastSuccessfulFetchAt`** alongside the existing community fields. Cached-data **`state`** still stays **`succeeded`** when `updatedAt` is present, even during background refresh; **`syncState`** tracks the live fetch lifecycle (`initializing` → `loading` / `retrying` → `succeeded` / `failed` / `stopped`).
> 
> The communities store maintains per-community **`syncStatuses`**, updated from PKC **`updatingstatechange`** events (with `waiting-retry` mapped to **`retrying`**) and set to **`failed`** when **`addCommunityToStore`** throws. **`deleteCommunity`** clears sync status and errors for that key. Types add **`CommunitySyncState`** and extend **`UseCommunityResult`**.
> 
> README / **`llms-full.txt`** document the new fields and example usage; changelog entries for **0.1.29** / **0.1.30**; tests cover the lifecycle, **`onlyIfCached`**, failures, and delete cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02b03533ee56914e14989030b09d304744a2d389. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added synchronization status information to community data, including loading, retrying, success, failure, and stopped states.
  * Added indicators for cached data availability and timestamps for fetch attempts and successful fetches.

* **Bug Fixes**
  * Community synchronization failures are now reflected consistently.
  * Removed synchronization status when a community is deleted.

* **Documentation**
  * Updated usage guidance and examples for the expanded community data returned by `useCommunity`.
  * Added release documentation for version 0.1.30.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->