### PR TITLE
chore(release): prepare 0.1.31

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.30",
+  "version": "0.1.31",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- prepare `@bitsocial/bitsocial-react-hooks` version `0.1.31`
- trigger the CI-owned npm and GitHub release flow after merge

## Verification

- `corepack yarn install`
- `corepack yarn prettier`
- `corepack yarn build`
- `corepack yarn knip`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only release metadata change with no runtime or API impact.
> 
> **Overview**
> Bumps `@bitsocial/bitsocial-react-hooks` from **0.1.30** to **0.1.31** in `package.json` as a release-prep step. Merging is intended to kick off the existing CI pipeline for npm publish and GitHub release; there are no library code or dependency changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9159607932256f71c40efc7a932006fb14ee92c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the package version from 0.1.30 to 0.1.31.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->