### PR TITLE
chore(release): prepare 0.1.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.31",
+  "version": "0.1.32",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- prepare `@bitsocial/bitsocial-react-hooks` 0.1.32
- let the master CI publish the reply propagation fix from #78 to npm and GitHub Releases

## Verification

- `corepack yarn install`
- `yarn build`
- `yarn lint` (196 existing warnings, 0 errors)
- `yarn type-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version-field change with no runtime or API edits in the diff.
> 
> **Overview**
> **Release prep only:** bumps `@bitsocial/bitsocial-react-hooks` from **0.1.31** to **0.1.32** in `package.json` so master CI can publish the reply propagation fix (from #78) to npm and GitHub Releases.
> 
> No library source or build config changes appear in this diff—only the version field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb3214881b60150bfd9b57076327a1564bef7078. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->