### PR TITLE
fix(accounts): speed up account backup imports

### DIFF
--- a/src/stores/accounts/account-generator.ts
+++ b/src/stores/accounts/account-generator.ts
@@ -118,6 +118,14 @@ export const getDefaultPkcOptions = () => {
 // @ts-ignore
 const defaultMediaIpfsGatewayUrl = window.defaultMediaIpfsGatewayUrl || "https://ipfs.io";
 
+export const getDefaultAccountFields = () => ({
+  subscriptions: [],
+  blockedAddresses: {},
+  blockedCids: {},
+  communities: {},
+  mediaIpfsGatewayUrl: defaultMediaIpfsGatewayUrl,
+});
+
 const generateDefaultAccount = async () => {
   const pkcOptions = getDefaultPkcOptions();
   const chainProviders = getDefaultChainProviders();
@@ -159,11 +167,8 @@ const generateDefaultAccount = async () => {
         signer,
         chainProviders,
         pkcOptions,
-        subscriptions: [],
-        blockedAddresses: {},
-        blockedCids: {},
+        ...getDefaultAccountFields(),
         communities,
-        mediaIpfsGatewayUrl: defaultMediaIpfsGatewayUrl,
       },
       pkc,
       pkcOptions,
@@ -201,6 +206,7 @@ const getNextAvailableDefaultAccountName = async () => {
 
 const accountGenerator = {
   generateDefaultAccount,
+  getDefaultAccountFields,
   getDefaultPkcOptions,
 };
 

--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -986,6 +986,44 @@ describe("accounts-actions", () => {
       }
     });
 
+    test("rolls back a newly registered account when history import fails", async () => {
+      await act(async () => {
+        await accountsActions.createAccount("Rollback Source");
+      });
+      const backup = JSON.parse(await accountsActions.exportAccount("Rollback Source"));
+      backup.account.name = "Rollback Import";
+      const accountIdsBefore =
+        await accountsDatabase.accountsMetadataDatabase.getItem("accountIds");
+      const accountNamesBefore = await accountsDatabase.accountsMetadataDatabase.getItem(
+        "accountNamesToAccountIds",
+      );
+      const accountKeysBefore = await accountsDatabase.accountsDatabase.keys();
+      const importAccountHistorySpy = vi
+        .spyOn(accountsDatabase, "importAccountHistory")
+        .mockRejectedValueOnce(new Error("simulated history import failure"));
+      const removeAccountSpy = vi.spyOn(accountsDatabase, "removeAccount");
+
+      try {
+        await expect(accountsActions.importAccount(JSON.stringify(backup))).rejects.toThrow(
+          "simulated history import failure",
+        );
+        expect(removeAccountSpy).toHaveBeenCalledTimes(1);
+        expect(await accountsDatabase.accountsMetadataDatabase.getItem("accountIds")).toEqual(
+          accountIdsBefore,
+        );
+        expect(
+          await accountsDatabase.accountsMetadataDatabase.getItem("accountNamesToAccountIds"),
+        ).toEqual(accountNamesBefore);
+        expect(await accountsDatabase.accountsDatabase.keys()).toEqual(accountKeysBefore);
+        expect(
+          accountsStore.getState().accountNamesToAccountIds["Rollback Import"],
+        ).toBeUndefined();
+      } finally {
+        importAccountHistorySpy.mockRestore();
+        removeAccountSpy.mockRestore();
+      }
+    });
+
     test("round-trips a 100 KiB backup with hundreds of history records through one bulk write", async () => {
       await act(async () => {
         await accountsActions.createAccount("Stress Source");

--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -960,6 +960,9 @@ describe("accounts-actions", () => {
       const exported = JSON.parse(await accountsActions.exportAccount("Portable"));
       const originalId = exported.account.id;
       const originalSigner = exported.account.signer;
+      delete exported.account.subscriptions;
+      delete exported.account.blockedAddresses;
+      delete exported.account.blockedCids;
       const generateDefaultAccountSpy = vi.spyOn(accountGenerator, "generateDefaultAccount");
       const importAccountHistorySpy = vi.spyOn(accountsDatabase, "importAccountHistory");
       try {
@@ -973,6 +976,9 @@ describe("accounts-actions", () => {
         expect(importedAccount.id).not.toBe(originalId);
         expect(importedAccount.signer).toEqual(originalSigner);
         expect(importedAccount.author.address).toBe(exported.account.author.address);
+        expect(importedAccount.subscriptions).toEqual([]);
+        expect(importedAccount.blockedAddresses).toEqual({});
+        expect(importedAccount.blockedCids).toEqual({});
         expect(importedAccount.pkc).toBeDefined();
       } finally {
         generateDefaultAccountSpy.mockRestore();

--- a/src/stores/accounts/accounts-actions.test.ts
+++ b/src/stores/accounts/accounts-actions.test.ts
@@ -5,6 +5,7 @@ import * as accountsActions from "./accounts-actions";
 import * as accountsActionsInternal from "./accounts-actions-internal";
 import accountsDatabase from "./accounts-database";
 import accountsStore from "./accounts-store";
+import accountGenerator from "./account-generator";
 import communitiesStore from "../communities";
 import commentsStore from "../comments";
 import PkcJsMock, {
@@ -950,6 +951,122 @@ describe("accounts-actions", () => {
       const { accountNamesToAccountIds } = accountsStore.getState();
       expect(accountNamesToAccountIds["Second"]).toBeDefined();
       expect(accountNamesToAccountIds["Second 2"]).toBeDefined();
+    });
+
+    test("imports the existing identity without generating disposable credentials", async () => {
+      await act(async () => {
+        await accountsActions.createAccount("Portable");
+      });
+      const exported = JSON.parse(await accountsActions.exportAccount("Portable"));
+      const originalId = exported.account.id;
+      const originalSigner = exported.account.signer;
+      const generateDefaultAccountSpy = vi.spyOn(accountGenerator, "generateDefaultAccount");
+      const importAccountHistorySpy = vi.spyOn(accountsDatabase, "importAccountHistory");
+      try {
+        await act(async () => {
+          await accountsActions.importAccount(JSON.stringify(exported));
+        });
+        const { accounts, accountNamesToAccountIds } = accountsStore.getState();
+        const importedAccount = accounts[accountNamesToAccountIds["Portable 2"]];
+        expect(generateDefaultAccountSpy).not.toHaveBeenCalled();
+        expect(importAccountHistorySpy).toHaveBeenCalledTimes(1);
+        expect(importedAccount.id).not.toBe(originalId);
+        expect(importedAccount.signer).toEqual(originalSigner);
+        expect(importedAccount.author.address).toBe(exported.account.author.address);
+        expect(importedAccount.pkc).toBeDefined();
+      } finally {
+        generateDefaultAccountSpy.mockRestore();
+        importAccountHistorySpy.mockRestore();
+      }
+    });
+
+    test("round-trips a 100 KiB backup with hundreds of history records through one bulk write", async () => {
+      await act(async () => {
+        await accountsActions.createAccount("Stress Source");
+      });
+      const backup = JSON.parse(await accountsActions.exportAccount("Stress Source"));
+      backup.account.name = "Stress Backup";
+      backup.accountComments = Array.from({ length: 120 }, (_, index) => ({
+        cid: `comment-${index}`,
+        communityAddress: "community.eth",
+        content: `synthetic comment ${index}`,
+        timestamp: 1_000 + index,
+      }));
+      backup.accountVotes = Array.from({ length: 120 }, (_, index) => ({
+        commentCid: `vote-target-${index % 30}`,
+        communityAddress: "community.eth",
+        vote: index % 2 === 0 ? 1 : -1,
+      }));
+      backup.accountEdits = Array.from({ length: 120 }, (_, index) => ({
+        commentCid: `edit-target-${index % 12}`,
+        communityAddress: "community.eth",
+        content: `synthetic edit ${index}`,
+        timestamp: 1_000 + index,
+      }));
+      backup.fixturePadding = "";
+      const targetBytes = 100 * 1024;
+      const paddingLength = targetBytes - JSON.stringify(backup).length;
+      expect(paddingLength).toBeGreaterThan(0);
+      backup.fixturePadding = "x".repeat(paddingLength);
+      const serializedBackup = JSON.stringify(backup);
+      expect(serializedBackup).toHaveLength(targetBytes);
+
+      const addCommentSpy = vi.spyOn(accountsDatabase, "addAccountComment");
+      const addVoteSpy = vi.spyOn(accountsDatabase, "addAccountVote");
+      const addEditSpy = vi.spyOn(accountsDatabase, "addAccountEdit");
+      const bulkImportSpy = vi.spyOn(accountsDatabase, "importAccountHistory");
+      const startUpdatingSpy = vi
+        .spyOn(accountsActionsInternal, "startUpdatingAccountCommentOnCommentUpdateEvents")
+        .mockResolvedValue(undefined);
+      try {
+        await act(async () => {
+          await accountsActions.importAccount(serializedBackup);
+        });
+        expect(bulkImportSpy).toHaveBeenCalledTimes(1);
+        expect(addCommentSpy).not.toHaveBeenCalled();
+        expect(addVoteSpy).not.toHaveBeenCalled();
+        expect(addEditSpy).not.toHaveBeenCalled();
+        expect(startUpdatingSpy).toHaveBeenCalledTimes(10);
+
+        const roundTripped = JSON.parse(await accountsActions.exportAccount("Stress Backup"));
+        expect(roundTripped.accountComments).toHaveLength(120);
+        expect(roundTripped.accountVotes).toHaveLength(120);
+        expect(roundTripped.accountEdits).toHaveLength(120);
+      } finally {
+        addCommentSpy.mockRestore();
+        addVoteSpy.mockRestore();
+        addEditSpy.mockRestore();
+        bulkImportSpy.mockRestore();
+        startUpdatingSpy.mockRestore();
+      }
+    });
+
+    test("starts update watchers for only the ten newest imported comments", async () => {
+      await act(async () => {
+        await accountsActions.createAccount("History");
+      });
+      const exported = JSON.parse(await accountsActions.exportAccount("History"));
+      exported.account.name = "Imported History";
+      exported.accountComments = Array.from({ length: 15 }, (_, index) => ({
+        cid: `comment-${index}`,
+        communityAddress: "community.eth",
+        content: `comment ${index}`,
+        timestamp: 1_000 + index,
+      }));
+      const startUpdatingSpy = vi
+        .spyOn(accountsActionsInternal, "startUpdatingAccountCommentOnCommentUpdateEvents")
+        .mockResolvedValue(undefined);
+      try {
+        await act(async () => {
+          await accountsActions.importAccount(JSON.stringify(exported));
+        });
+        expect(startUpdatingSpy).toHaveBeenCalledTimes(10);
+        expect(startUpdatingSpy.mock.calls.map(([comment]) => comment.timestamp)).toEqual([
+          1_014, 1_013, 1_012, 1_011, 1_010, 1_009, 1_008, 1_007, 1_006, 1_005,
+        ]);
+      } finally {
+        startUpdatingSpy.mockRestore();
+      }
     });
 
     test("deleteCommunity with accountName uses named account", async () => {

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -660,19 +660,25 @@ export const importAccount = async (serializedAccount: string) => {
     returnHydratedAccount: true,
   });
   assert(newAccount, `accountsActions.importAccount failed to hydrate imported account`);
-  const [
-    { accountComments, accountVotes, accountEditsSummary },
-    accountIds,
-    newAccountNamesToAccountIds,
-  ] = await Promise.all<any>([
-    accountsDatabase.importAccountHistory(newAccount.id, {
+  let importedHistory;
+  let accountIds;
+  let newAccountNamesToAccountIds;
+  try {
+    importedHistory = await accountsDatabase.importAccountHistory(newAccount.id, {
       accountComments: imported.accountComments || [],
       accountVotes: imported.accountVotes || [],
       accountEdits: imported.accountEdits || [],
-    }),
-    accountsDatabase.accountsMetadataDatabase.getItem("accountIds"),
-    accountsDatabase.accountsMetadataDatabase.getItem("accountNamesToAccountIds"),
-  ]);
+    });
+    [accountIds, newAccountNamesToAccountIds] = await Promise.all<any>([
+      accountsDatabase.accountsMetadataDatabase.getItem("accountIds"),
+      accountsDatabase.accountsMetadataDatabase.getItem("accountNamesToAccountIds"),
+    ]);
+  } catch (error) {
+    await accountsDatabase.removeAccount(newAccount);
+    void newAccount.pkc?.destroy?.();
+    throw error;
+  }
+  const { accountComments, accountVotes, accountEditsSummary } = importedHistory;
 
   accountsStore.setState((state) => ({
     accounts: { ...state.accounts, [newAccount.id]: newAccount },

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -648,6 +648,7 @@ export const importAccount = async (serializedAccount: string) => {
 
   // Always assign a new local id so importing the same backup cannot overwrite an existing account.
   const accountToImport = {
+    ...accountGenerator.getDefaultAccountFields(),
     ...imported.account,
     communities,
     id: uuid(),

--- a/src/stores/accounts/accounts-actions.ts
+++ b/src/stores/accounts/accounts-actions.ts
@@ -49,6 +49,7 @@ import {
   sanitizeAccountCommentForState,
   sanitizeStoredAccountComment,
   getFreshestLoadedComment,
+  getInitAccountCommentsToUpdate,
 } from "./utils";
 import isEqual from "lodash.isequal";
 import { v4 as uuid } from "uuid";
@@ -640,50 +641,34 @@ export const importAccount = async (serializedAccount: string) => {
     imported.account,
     communitiesStore.getState().communities,
   );
-
   // if imported.account.name already exists, add ' 2', don't overwrite
   if (accountNamesToAccountIds[imported.account.name]) {
     imported.account.name += " 2";
   }
 
-  // generate new account
-  const generatedAccount = await accountGenerator.generateDefaultAccount();
-  // use generatedAccount to init properties like .pkc and .id on a new account
-  // overwrite account.id to avoid duplicate ids
-  const newAccount = {
-    ...generatedAccount,
+  // Always assign a new local id so importing the same backup cannot overwrite an existing account.
+  const accountToImport = {
     ...imported.account,
     communities,
-    id: generatedAccount.id,
+    id: uuid(),
   };
 
-  // add account to database
-  await accountsDatabase.addAccount(newAccount);
-
-  // add account comments, votes, edits to database
-  for (const accountComment of imported.accountComments || []) {
-    await accountsDatabase.addAccountComment(newAccount.id, accountComment);
-  }
-  for (const accountVote of imported.accountVotes || []) {
-    await accountsDatabase.addAccountVote(newAccount.id, accountVote);
-  }
-  for (const accountEdit of imported.accountEdits || []) {
-    await accountsDatabase.addAccountEdit(newAccount.id, accountEdit);
-  }
-
-  // set new state
-
-  // get new state data from database because it's easier
+  // Hydrate the imported identity once, then persist its history in bulk instead of replaying
+  // every record through the single-publication write path.
+  const newAccount = await accountsDatabase.addAccount(accountToImport, {
+    returnHydratedAccount: true,
+  });
+  assert(newAccount, `accountsActions.importAccount failed to hydrate imported account`);
   const [
-    accountComments,
-    accountVotes,
-    accountEditsSummary,
+    { accountComments, accountVotes, accountEditsSummary },
     accountIds,
     newAccountNamesToAccountIds,
   ] = await Promise.all<any>([
-    accountsDatabase.getAccountComments(newAccount.id),
-    accountsDatabase.getAccountVotes(newAccount.id),
-    accountsDatabase.getAccountEditsSummary(newAccount.id),
+    accountsDatabase.importAccountHistory(newAccount.id, {
+      accountComments: imported.accountComments || [],
+      accountVotes: imported.accountVotes || [],
+      accountEdits: imported.accountEdits || [],
+    }),
     accountsDatabase.accountsMetadataDatabase.getItem("accountIds"),
     accountsDatabase.accountsMetadataDatabase.getItem("accountNamesToAccountIds"),
   ]);
@@ -719,8 +704,11 @@ export const importAccount = async (serializedAccount: string) => {
     accountEditsSummary,
   });
 
-  // start looking for updates for all accounts comments in database
-  for (const accountComment of accountComments) {
+  // Match normal startup: refresh only the ten newest comments instead of opening a watcher
+  // for the entire imported history at once.
+  for (const { accountComment } of getInitAccountCommentsToUpdate({
+    [newAccount.id]: accountComments,
+  })) {
     accountsStore
       .getState()
       .accountsActionsInternal.startUpdatingAccountCommentOnCommentUpdateEvents(

--- a/src/stores/accounts/accounts-database.test.ts
+++ b/src/stores/accounts/accounts-database.test.ts
@@ -1,4 +1,4 @@
-import accountsDatabase from "./accounts-database";
+import accountsDatabase, { replaceDatabaseArraysWithRollback } from "./accounts-database";
 import { setPkcJs, restorePkcJs } from "../../lib/pkc-js";
 import PkcJsMock from "../../lib/pkc-js/pkc-js-mock";
 import localForage from "localforage";
@@ -816,6 +816,37 @@ describe("accounts-database", () => {
   });
 
   describe("importAccountHistory", () => {
+    test("reports both replacement and rollback failures", async () => {
+      const values = new Map<string, any>([
+        ["0", { phase: "old" }],
+        ["length", 1],
+      ]);
+      const database = {
+        clear: vi.fn(async () => values.clear()),
+        keys: vi.fn(async () => [...values.keys()]),
+        getItem: vi.fn(async (key: string) => values.get(key)),
+        setItem: vi.fn(async (key: string, value: any) => {
+          if (value?.phase === "new") {
+            throw new Error("simulated replacement failure");
+          }
+          if (value?.phase === "old") {
+            throw new Error("simulated rollback failure");
+          }
+          values.set(key, value);
+        }),
+      };
+
+      const error = await replaceDatabaseArraysWithRollback([
+        { database, items: [{ phase: "new" }], metadata: {} },
+      ]).catch((caughtError) => caughtError);
+
+      expect(error.message).toBe(
+        "importAccountHistory failed and could not restore previous history",
+      );
+      expect(error.cause.message).toBe("simulated replacement failure");
+      expect(error.rollbackError.message).toBe("simulated rollback failure");
+    });
+
     test("persists and returns compact comments plus indexed vote and edit state in bulk", async () => {
       const acc = makeAccount({ id: "bulk-history", name: "BulkHistory" });
       await accountsDatabase.addAccount(acc);
@@ -921,6 +952,57 @@ describe("accounts-database", () => {
           accountEdits: [{} as any],
         }),
       ).rejects.toThrow("addAccountEdit target 'undefined' not a string");
+    });
+
+    test("restores every history store if one bulk replacement fails", async () => {
+      const acc = makeAccount({ id: "bulk-rollback", name: "BulkRollback" });
+      await accountsDatabase.addAccount(acc);
+      const commentsDb = createPerAccountDatabase("accountComments", acc.id);
+      const votesDb = createPerAccountDatabase("accountVotes", acc.id);
+      const editsDb = createPerAccountDatabase("accountEdits", acc.id);
+      const oldComment = { cid: "old-comment", content: "old", timestamp: 1 };
+      const oldVote = { commentCid: "old-vote", vote: 1 };
+      const oldEdit = { commentCid: "old-edit", content: "old", timestamp: 1 };
+      await Promise.all([
+        commentsDb.setItem("0", oldComment),
+        commentsDb.setItem("length", 1),
+        commentsDb.setItem("__storageVersion", 2),
+        votesDb.setItem("0", oldVote),
+        votesDb.setItem("length", 1),
+        votesDb.setItem("__commentCidToLatestIndex", { "old-vote": 0 }),
+        votesDb.setItem("__storageVersion", 1),
+        editsDb.setItem("0", oldEdit),
+        editsDb.setItem("length", 1),
+        editsDb.setItem("__targetToIndices", { "old-edit": [0] }),
+        editsDb.setItem("__summary", {
+          "old-edit": { content: { timestamp: 1, value: "old" } },
+        }),
+        editsDb.setItem("__storageVersion", 1),
+      ]);
+
+      await expect(
+        accountsDatabase.importAccountHistory(acc.id, {
+          accountComments: [{ cid: "new-comment", content: "new", timestamp: 2 }] as any,
+          accountVotes: [
+            {
+              commentCid: "new-vote",
+              vote: -1,
+              uncloneable: { callback: () => {} },
+            },
+          ] as any,
+          accountEdits: [{ commentCid: "new-edit", content: "new", timestamp: 2 }] as any,
+        }),
+      ).rejects.toBeDefined();
+
+      const exported = JSON.parse(await accountsDatabase.getExportedAccountJson(acc.id));
+      expect(exported.accountComments).toEqual([oldComment]);
+      expect(exported.accountVotes).toEqual([oldVote]);
+      expect(exported.accountEdits).toEqual([oldEdit]);
+      expect(await votesDb.getItem("__commentCidToLatestIndex")).toEqual({ "old-vote": 0 });
+      expect(await editsDb.getItem("__targetToIndices")).toEqual({ "old-edit": [0] });
+      expect(await editsDb.getItem("__summary")).toEqual({
+        "old-edit": { content: { timestamp: 1, value: "old" } },
+      });
     });
   });
 

--- a/src/stores/accounts/accounts-database.test.ts
+++ b/src/stores/accounts/accounts-database.test.ts
@@ -410,6 +410,19 @@ describe("accounts-database", () => {
       );
     });
 
+    test("rejects duplicate name when its metadata mapping is missing", async () => {
+      const existing = makeAccount({ id: "missing-map-existing", name: "MissingMap" });
+      await accountsDatabase.addAccount(existing);
+      await accountsDatabase.accountsMetadataDatabase.setItem("accountNamesToAccountIds", {});
+
+      await expect(
+        accountsDatabase.addAccount(
+          makeAccount({ id: "missing-map-replacement", name: "MissingMap" }),
+        ),
+      ).rejects.toThrow("account name 'MissingMap' already exists in database");
+      expect(await accountsDatabase.accountsDatabase.getItem("missing-map-replacement")).toBeNull();
+    });
+
     test("strips default pkc options from stored account", async () => {
       const acc = makeAccount({ pkcOptions: getDefaultPkcOptions() });
       await accountsDatabase.addAccount(acc);

--- a/src/stores/accounts/accounts-database.test.ts
+++ b/src/stores/accounts/accounts-database.test.ts
@@ -474,6 +474,34 @@ describe("accounts-database", () => {
         setPkcJs(PkcJsMock);
       }
     });
+
+    test("returns one hydrated account client for import without destroying it", async () => {
+      const acc = makeAccount({ id: "hydrated-import", name: "HydratedImport" });
+      const destroySpy = vi.fn().mockResolvedValue(undefined);
+      const OrigPkc = (await import("../../lib/pkc-js")).default.PKC;
+      const WrapperPkc = async (opts: any) => {
+        const pkc = await OrigPkc(opts);
+        pkc.destroy = destroySpy;
+        return pkc;
+      };
+      setPkcJs(WrapperPkc);
+      try {
+        const hydratedAccount = await accountsDatabase.addAccount(acc, {
+          returnHydratedAccount: true,
+        });
+        expect(hydratedAccount).toMatchObject({
+          id: acc.id,
+          name: acc.name,
+          author: acc.author,
+          signer: acc.signer,
+        });
+        expect(hydratedAccount?.pkc).toBeDefined();
+        expect(hydratedAccount?.pkcOptions).toEqual(getDefaultPkcOptions());
+        expect(destroySpy).not.toHaveBeenCalled();
+      } finally {
+        setPkcJs(PkcJsMock);
+      }
+    });
   });
 
   describe("removeAccount", () => {
@@ -761,6 +789,115 @@ describe("accounts-database", () => {
       expect(edits["legacy-community.eth"][0].description).toBe("legacy");
       expect(summary["community.eth"].title.value).toBe("community");
       expect(summary["legacy-community.eth"].description.value).toBe("legacy");
+    });
+  });
+
+  describe("importAccountHistory", () => {
+    test("persists and returns compact comments plus indexed vote and edit state in bulk", async () => {
+      const acc = makeAccount({ id: "bulk-history", name: "BulkHistory" });
+      await accountsDatabase.addAccount(acc);
+      const accountComments = [
+        {
+          cid: "comment-1",
+          content: "first",
+          communityAddress: "community.eth",
+          timestamp: 1,
+          signer: { privateKey: "secret" },
+          raw: { oversized: true },
+          replies: {
+            pages: { best: { comments: [{ cid: "cached-reply" }] } },
+            pageCids: { best: "page-1" },
+          },
+        },
+        {
+          cid: "comment-2",
+          content: "second",
+          communityAddress: "community.eth",
+          timestamp: 2,
+        },
+      ] as any;
+      const accountVotes = [
+        {
+          commentCid: "vote-target",
+          communityAddress: "community.eth",
+          vote: 1,
+          signer: { privateKey: "secret" },
+        },
+        {
+          commentCid: "vote-target",
+          communityAddress: "community.eth",
+          vote: -1,
+        },
+      ] as any;
+      const accountEdits = [
+        {
+          commentCid: "edit-target",
+          communityAddress: "community.eth",
+          content: "first edit",
+          timestamp: 1,
+        },
+        {
+          commentCid: "edit-target",
+          communityAddress: "community.eth",
+          content: "second edit",
+          timestamp: 2,
+        },
+      ] as any;
+
+      const imported = await accountsDatabase.importAccountHistory(acc.id, {
+        accountComments,
+        accountVotes,
+        accountEdits,
+      });
+
+      expect(imported.accountComments).toEqual([
+        expect.objectContaining({ cid: "comment-1", index: 0, accountId: acc.id }),
+        expect.objectContaining({ cid: "comment-2", index: 1, accountId: acc.id }),
+      ]);
+      expect(imported.accountComments[0].signer).toBeUndefined();
+      expect(imported.accountComments[0].raw).toBeUndefined();
+      expect(imported.accountComments[0].replies?.pages).toBeUndefined();
+      expect(imported.accountComments[0].replies?.pageCids).toEqual({ best: "page-1" });
+      expect(imported.accountVotes["vote-target"].vote).toBe(-1);
+      expect(imported.accountVotes["vote-target"].signer).toBeUndefined();
+      expect(imported.accountEditsSummary["edit-target"].content).toEqual({
+        timestamp: 2,
+        value: "second edit",
+      });
+
+      const exported = JSON.parse(await accountsDatabase.getExportedAccountJson(acc.id));
+      expect(exported.accountComments).toHaveLength(2);
+      expect(exported.accountVotes).toHaveLength(2);
+      expect(exported.accountEdits).toHaveLength(2);
+      expect(await accountsDatabase.getAccountVotes(acc.id)).toEqual(imported.accountVotes);
+      expect(await accountsDatabase.getAccountEditsSummary(acc.id)).toEqual(
+        imported.accountEditsSummary,
+      );
+    });
+
+    test("supports empty history", async () => {
+      const acc = makeAccount({ id: "bulk-empty", name: "BulkEmpty" });
+      await accountsDatabase.addAccount(acc);
+      await expect(accountsDatabase.importAccountHistory(acc.id, {})).resolves.toEqual({
+        accountComments: [],
+        accountVotes: {},
+        accountEditsSummary: {},
+      });
+    });
+
+    test("rejects invalid vote and edit targets before writing history", async () => {
+      const acc = makeAccount({ id: "bulk-invalid", name: "BulkInvalid" });
+      await accountsDatabase.addAccount(acc);
+      await expect(
+        accountsDatabase.importAccountHistory(acc.id, {
+          accountVotes: [{} as any],
+        }),
+      ).rejects.toThrow("addAccountVote createVoteOptions.commentCid 'undefined' not a string");
+      await expect(
+        accountsDatabase.importAccountHistory(acc.id, {
+          accountEdits: [{} as any],
+        }),
+      ).rejects.toThrow("addAccountEdit target 'undefined' not a string");
     });
   });
 

--- a/src/stores/accounts/accounts-database.test.ts
+++ b/src/stores/accounts/accounts-database.test.ts
@@ -376,6 +376,29 @@ describe("accounts-database", () => {
       await accountsDatabase.addAccount(updated);
       const stored = await accountsDatabase.accountsDatabase.getItem(acc.id);
       expect(stored.name).toBe("Updated");
+      const accountNamesToAccountIds = await accountsDatabase.accountsMetadataDatabase.getItem(
+        "accountNamesToAccountIds",
+      );
+      expect(accountNamesToAccountIds).toEqual({ Updated: "update-acc" });
+    });
+
+    test("ignores stale name mappings when a vacated name is reused", async () => {
+      const existing = makeAccount({ id: "existing", name: "Current" });
+      await accountsDatabase.addAccount(existing);
+      await accountsDatabase.accountsMetadataDatabase.setItem("accountNamesToAccountIds", {
+        Current: "existing",
+        Vacated: "existing",
+      });
+
+      await accountsDatabase.addAccount(makeAccount({ id: "replacement", name: "Vacated" }));
+
+      const accountNamesToAccountIds = await accountsDatabase.accountsMetadataDatabase.getItem(
+        "accountNamesToAccountIds",
+      );
+      expect(accountNamesToAccountIds).toEqual({
+        Current: "existing",
+        Vacated: "replacement",
+      });
     });
 
     test("rejects duplicate name", async () => {

--- a/src/stores/accounts/accounts-database.ts
+++ b/src/stores/accounts/accounts-database.ts
@@ -349,6 +349,16 @@ const addAccount = async (account: Account, options?: { returnHydratedAccount?: 
     }
     delete accountNamesToAccountIds[account.name];
   }
+  if (accountIds?.length) {
+    const storedAccounts = await Promise.all(
+      accountIds
+        .filter((accountId) => accountId !== account.id)
+        .map((accountId) => accountsDatabase.getItem<Account>(accountId)),
+    );
+    if (storedAccounts.some((storedAccount) => storedAccount?.name === account.name)) {
+      throw Error(`account name '${account.name}' already exists in database`);
+    }
+  }
 
   // handle updating accounts database
   const accountToPutInDatabase: any = normalizeAccountProtocolConfig({

--- a/src/stores/accounts/accounts-database.ts
+++ b/src/stores/accounts/accounts-database.ts
@@ -288,10 +288,17 @@ const addAccount = async (account: Account, options?: { returnHydratedAccount?: 
     accountsMetadataDatabase.getItem<string[]>("accountIds"),
     accountsMetadataDatabase.getItem<AccountNamesToAccountIds>("accountNamesToAccountIds"),
   ]);
+  if (!accountNamesToAccountIds) {
+    accountNamesToAccountIds = {};
+  }
   // handle no duplicate names
-  const existingAccountId = accountNamesToAccountIds?.[account.name];
+  const existingAccountId = accountNamesToAccountIds[account.name];
   if (existingAccountId && existingAccountId !== account.id) {
-    throw Error(`account name '${account.name}' already exists in database`);
+    const existingAccount = await accountsDatabase.getItem<Account>(existingAccountId);
+    if (existingAccount?.name === account.name) {
+      throw Error(`account name '${account.name}' already exists in database`);
+    }
+    delete accountNamesToAccountIds[account.name];
   }
 
   // handle updating accounts database
@@ -327,8 +334,10 @@ const addAccount = async (account: Account, options?: { returnHydratedAccount?: 
   await accountsDatabase.setItem(accountToPutInDatabase.id, accountToPutInDatabase);
 
   // handle updating accountNamesToAccountIds database
-  if (!accountNamesToAccountIds) {
-    accountNamesToAccountIds = {};
+  for (const [accountName, accountId] of Object.entries(accountNamesToAccountIds)) {
+    if (accountId === account.id && accountName !== account.name) {
+      delete accountNamesToAccountIds[accountName];
+    }
   }
   accountNamesToAccountIds[account.name] = account.id;
   await accountsMetadataDatabase.setItem("accountNamesToAccountIds", accountNamesToAccountIds);

--- a/src/stores/accounts/accounts-database.ts
+++ b/src/stores/accounts/accounts-database.ts
@@ -244,6 +244,55 @@ const replaceDatabaseArray = async (database: any, items: any[], metadata: Recor
   ]);
 };
 
+const getDatabaseSnapshot = async (database: any) => {
+  const keys: string[] = await database.keys();
+  return Promise.all(keys.map(async (key) => [key, await database.getItem(key)] as [string, any]));
+};
+
+const restoreDatabaseSnapshot = async (database: any, snapshot: [string, any][]) => {
+  await database.clear();
+  await Promise.all(snapshot.map(([key, value]) => database.setItem(key, value)));
+};
+
+export const replaceDatabaseArraysWithRollback = async (
+  replacements: {
+    database: any;
+    items: any[];
+    metadata: Record<string, any>;
+  }[],
+) => {
+  const snapshots = await Promise.all(
+    replacements.map(({ database }) => getDatabaseSnapshot(database)),
+  );
+  const replacementResults = await Promise.allSettled(
+    replacements.map(({ database, items, metadata }) =>
+      replaceDatabaseArray(database, items, metadata),
+    ),
+  );
+  const replacementFailure = replacementResults.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (!replacementFailure) {
+    return;
+  }
+
+  const rollbackResults = await Promise.allSettled(
+    replacements.map(({ database }, index) => restoreDatabaseSnapshot(database, snapshots[index])),
+  );
+  const rollbackFailure = rollbackResults.find(
+    (result): result is PromiseRejectedResult => result.status === "rejected",
+  );
+  if (rollbackFailure) {
+    const rollbackError = new Error(
+      `importAccountHistory failed and could not restore previous history`,
+    );
+    (rollbackError as any).cause = replacementFailure.reason;
+    (rollbackError as any).rollbackError = rollbackFailure.reason;
+    throw rollbackError;
+  }
+  throw replacementFailure.reason;
+};
+
 const removeFunctionsAndSensitiveFields = (publication: CreateCommentOptions) => {
   const sanitizedPublication: Record<string, any> = {};
   for (const key in publication) {
@@ -849,6 +898,10 @@ const getAccountsEditsSummaries = async (accountIds: string[]) => {
   );
 };
 
+/**
+ * Replaces all comments, votes, and edits for an account. If any store replacement fails,
+ * every history store is restored to its exact pre-call state before the error is rethrown.
+ */
 const importAccountHistory = async (
   accountId: string,
   {
@@ -886,19 +939,34 @@ const importAccountHistory = async (
     ),
   );
 
-  await Promise.all([
-    replaceDatabaseArray(getAccountCommentsDatabase(accountId), storedComments, {
-      [storageVersionKey]: commentStorageVersion,
-    }),
-    replaceDatabaseArray(getAccountVotesDatabase(accountId), storedVotes, {
-      [votesLatestIndexKey]: latestVoteIndexByCommentCid,
-      [storageVersionKey]: voteStorageVersion,
-    }),
-    replaceDatabaseArray(getAccountEditsDatabase(accountId), storedEdits, {
-      [editsTargetToIndicesKey]: editTargetToIndices,
-      [editsSummaryKey]: accountEditsSummary,
-      [storageVersionKey]: editStorageVersion,
-    }),
+  const historyDatabases = [
+    getAccountCommentsDatabase(accountId),
+    getAccountVotesDatabase(accountId),
+    getAccountEditsDatabase(accountId),
+  ];
+  await replaceDatabaseArraysWithRollback([
+    {
+      database: historyDatabases[0],
+      items: storedComments,
+      metadata: { [storageVersionKey]: commentStorageVersion },
+    },
+    {
+      database: historyDatabases[1],
+      items: storedVotes,
+      metadata: {
+        [votesLatestIndexKey]: latestVoteIndexByCommentCid,
+        [storageVersionKey]: voteStorageVersion,
+      },
+    },
+    {
+      database: historyDatabases[2],
+      items: storedEdits,
+      metadata: {
+        [editsTargetToIndicesKey]: editTargetToIndices,
+        [editsSummaryKey]: accountEditsSummary,
+        [storageVersionKey]: editStorageVersion,
+      },
+    },
   ]);
 
   const accountCommentsWithIndexes = storedComments.map((comment, index) => ({

--- a/src/stores/accounts/accounts-database.ts
+++ b/src/stores/accounts/accounts-database.ts
@@ -103,22 +103,15 @@ const migrate = async () => {
   await Promise.all(promises);
 };
 
-const getAccounts = async (accountIds: string[]) => {
-  validator.validateAccountsDatabaseGetAccountsArguments(accountIds);
+const getAccountsFromStoredAccounts = async (storedAccounts: Accounts) => {
   const accounts: Accounts = {};
-  const promises = [];
-  for (const accountId of accountIds) {
-    promises.push(accountsDatabase.getItem(accountId));
-  }
-  const accountsArray: any = await Promise.all(promises);
-  for (const [i, accountId] of accountIds.entries()) {
-    assert(accountsArray[i], `accountId '${accountId}' not found in database`);
+  for (const [accountId, storedAccount] of Object.entries(storedAccounts)) {
     accounts[accountId] = normalizeAccountProtocolConfig(
-      await migrateAccount(accountsArray[i]),
+      await migrateAccount(storedAccount),
       getDefaultChainProviders(),
     );
     // protocol options aren't saved to database if they are default
-    if (!accounts[accountId].pkcOptions && !accounts[accountId].pkcOptions) {
+    if (!accounts[accountId].pkcOptions) {
       accounts[accountId].pkcOptions = getDefaultPkcOptions();
     }
     const protocolOptions = {
@@ -134,6 +127,19 @@ const getAccounts = async (accountIds: string[]) => {
     accounts[accountId] = withProtocolAliases(accounts[accountId], pkc, protocolOptions);
   }
   return accounts;
+};
+
+const getAccounts = async (accountIds: string[]) => {
+  validator.validateAccountsDatabaseGetAccountsArguments(accountIds);
+  const accountsArray: any = await Promise.all(
+    accountIds.map((accountId) => accountsDatabase.getItem(accountId)),
+  );
+  const storedAccounts: Accounts = {};
+  for (const [index, accountId] of accountIds.entries()) {
+    assert(accountsArray[index], `accountId '${accountId}' not found in database`);
+    storedAccounts[accountId] = accountsArray[index];
+  }
+  return getAccountsFromStoredAccounts(storedAccounts);
 };
 
 const accountVersion = 5;
@@ -229,6 +235,15 @@ const getDatabaseAsArray = async (database: any) => {
   return items;
 };
 
+const replaceDatabaseArray = async (database: any, items: any[], metadata: Record<string, any>) => {
+  await database.clear();
+  await Promise.all([
+    ...items.map((item, index) => database.setItem(String(index), item)),
+    database.setItem("length", items.length),
+    ...Object.entries(metadata).map(([key, value]) => database.setItem(key, value)),
+  ]);
+};
+
 const removeFunctionsAndSensitiveFields = (publication: CreateCommentOptions) => {
   const sanitizedPublication: Record<string, any> = {};
   for (const key in publication) {
@@ -267,18 +282,16 @@ const rebuildEditsTargetIndexes = (edits: any[]) => {
   return targetToIndices;
 };
 
-const addAccount = async (account: Account) => {
+const addAccount = async (account: Account, options?: { returnHydratedAccount?: boolean }) => {
   validator.validateAccountsDatabaseAddAccountArguments(account);
-  let accountIds: string[] | null = await accountsMetadataDatabase.getItem("accountIds");
-
+  let [accountIds, accountNamesToAccountIds] = await Promise.all([
+    accountsMetadataDatabase.getItem<string[]>("accountIds"),
+    accountsMetadataDatabase.getItem<AccountNamesToAccountIds>("accountNamesToAccountIds"),
+  ]);
   // handle no duplicate names
-  if (accountIds?.length) {
-    const accounts: Accounts = await getAccounts(accountIds);
-    for (const accountId of accountIds) {
-      if (accountId !== account.id && accounts[accountId].name === account.name) {
-        throw Error(`account name '${account.name}' already exists in database`);
-      }
-    }
+  const existingAccountId = accountNamesToAccountIds?.[account.name];
+  if (existingAccountId && existingAccountId !== account.id) {
+    throw Error(`account name '${account.name}' already exists in database`);
   }
 
   // handle updating accounts database
@@ -299,7 +312,14 @@ const addAccount = async (account: Account) => {
     delete accountToPutInDatabase.chainProviders;
   }
   // make sure accountToPutInDatabase protocol options are valid
-  if (protocolOptions) {
+  let hydratedAccount: Account | undefined;
+  if (options?.returnHydratedAccount) {
+    hydratedAccount = (
+      await getAccountsFromStoredAccounts({
+        [accountToPutInDatabase.id]: accountToPutInDatabase,
+      })
+    )[accountToPutInDatabase.id];
+  } else if (protocolOptions) {
     const pkc = await PkcJs.PKC(getPkcClientOptions(accountToPutInDatabase, protocolOptions));
     pkc.on("error", () => {});
     void pkc.destroy?.(); // gc; errors intentionally unhandled to avoid uncounted callback
@@ -307,8 +327,6 @@ const addAccount = async (account: Account) => {
   await accountsDatabase.setItem(accountToPutInDatabase.id, accountToPutInDatabase);
 
   // handle updating accountNamesToAccountIds database
-  let accountNamesToAccountIds: AccountNamesToAccountIds | null =
-    await accountsMetadataDatabase.getItem("accountNamesToAccountIds");
   if (!accountNamesToAccountIds) {
     accountNamesToAccountIds = {};
   }
@@ -328,6 +346,7 @@ const addAccount = async (account: Account) => {
   if (accountIds.length === 1) {
     await accountsMetadataDatabase.setItem("activeAccountId", account.id);
   }
+  return hydratedAccount;
 };
 
 const removeAccount = async (account: Account) => {
@@ -821,6 +840,77 @@ const getAccountsEditsSummaries = async (accountIds: string[]) => {
   );
 };
 
+const importAccountHistory = async (
+  accountId: string,
+  {
+    accountComments = [],
+    accountVotes = [],
+    accountEdits = [],
+  }: {
+    accountComments?: Comment[];
+    accountVotes?: CreateCommentOptions[];
+    accountEdits?: CreateCommentOptions[];
+  },
+) => {
+  const storedComments = accountComments.map((comment) => sanitizeStoredAccountComment(comment));
+  const storedVotes = accountVotes.map((vote) => {
+    assert(
+      vote?.commentCid && typeof vote.commentCid === "string",
+      `addAccountVote createVoteOptions.commentCid '${vote?.commentCid}' not a string`,
+    );
+    return removeFunctionsAndSensitiveFields(vote);
+  });
+  const storedEdits = accountEdits.map((edit) => {
+    const editTarget = getAccountEditTarget(edit as AccountEdit);
+    assert(typeof editTarget === "string", `addAccountEdit target '${editTarget}' not a string`);
+    return removeFunctionsAndSensitiveFields(edit);
+  });
+
+  const latestVoteIndexByCommentCid = rebuildVotesLatestIndex(storedVotes);
+  const editTargetToIndices = rebuildEditsTargetIndexes(storedEdits);
+  const accountEditsSummary = getAccountsEditsSummary(
+    Object.fromEntries(
+      Object.entries(editTargetToIndices).map(([target, indices]) => [
+        target,
+        indices.map((index) => storedEdits[index]).filter(Boolean),
+      ]),
+    ),
+  );
+
+  await Promise.all([
+    replaceDatabaseArray(getAccountCommentsDatabase(accountId), storedComments, {
+      [storageVersionKey]: commentStorageVersion,
+    }),
+    replaceDatabaseArray(getAccountVotesDatabase(accountId), storedVotes, {
+      [votesLatestIndexKey]: latestVoteIndexByCommentCid,
+      [storageVersionKey]: voteStorageVersion,
+    }),
+    replaceDatabaseArray(getAccountEditsDatabase(accountId), storedEdits, {
+      [editsTargetToIndicesKey]: editTargetToIndices,
+      [editsSummaryKey]: accountEditsSummary,
+      [storageVersionKey]: editStorageVersion,
+    }),
+  ]);
+
+  const accountCommentsWithIndexes = storedComments.map((comment, index) => ({
+    ...comment,
+    index,
+    accountId,
+  }));
+  const accountVotesByCommentCid = Object.fromEntries(
+    Object.entries(latestVoteIndexByCommentCid).map(([commentCid, index]) => [
+      commentCid,
+      storedVotes[index],
+    ]),
+  );
+
+  return {
+    accountComments: accountCommentsWithIndexes,
+    accountVotes: accountVotesByCommentCid,
+    accountEditsSummary,
+  };
+};
+
 const database = {
   accountsDatabase,
   accountsMetadataDatabase,
@@ -845,6 +935,7 @@ const database = {
   getAccountEditsSummary,
   addAccountEdit,
   deleteAccountEdit,
+  importAccountHistory,
   accountVersion,
   migrate,
   getAccountsDatabaseName,


### PR DESCRIPTION
## Summary

- import the backed-up identity directly instead of generating and deleting disposable credentials
- bulk-write comments, votes, and edits, then rebuild derived indexes once per import
- limit post-import comment refresh subscriptions to the ten newest comments
- add regression tests for compacted records, index rebuilding, and import orchestration

## Root cause

Account backups were replayed one record at a time through normal mutation paths. In particular, every imported edit rebuilt derived indexes and post summaries, making larger imports effectively quadratic. The flow also created an unused default account and started a refresh watcher for every imported comment.

## Impact

A 100 KiB account file is not inherently excessive. In a production 5chan preview, representative 100 KiB imports improved as follows:

| Fixture | Released hooks | This branch |
| --- | ---: | ---: |
| 250 comments | 679.4 ms | 151.8 ms |
| 400 votes | 1159.4 ms | 159.2 ms |
| 300 edits | 2405.4 ms | 112.4 ms |

A mixed 100 KiB account imported in 90.7 ms normally and 507.9 ms under 4x CPU throttling with constrained networking. Import and re-export preserved all 100 comments, 100 votes, and 50 edits. No 5chan source change is required.

## Verification

- corepack yarn test --reporter=dot (1154 passed, 6 skipped)
- corepack yarn test:coverage --reporter=dot (97.26% overall)
- node scripts/verify-hooks-stores-coverage.mjs
- corepack yarn type-check
- corepack yarn lint (0 errors; existing warnings only)
- corepack yarn knip
- corepack yarn prettier
- corepack yarn build
- git diff --check
- production 5chan preview import/export round-trip with synthetic 100 KiB account fixtures

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch local account identity, IndexedDB history writes, and import failure rollback; mistakes could corrupt or partially apply account data, though extensive new tests cover bulk import and rollback paths.
> 
> **Overview**
> **Account backup import** no longer creates a disposable default account and replays each comment, vote, and edit through the normal single-record APIs. Imports merge **`getDefaultAccountFields()`** with the backup, assign a **new local `id`** (so re-import cannot overwrite), hydrate once via **`addAccount(..., { returnHydratedAccount: true })`**, then persist history through **`importAccountHistory`** in one bulk replace with snapshot rollback on failure; failed history import **removes the new account** and destroys its PKC client.
> 
> **`importAccountHistory`** sanitizes comments/votes/edits, rebuilds vote and edit indexes and summaries once, and uses **`replaceDatabaseArraysWithRollback`** across the three per-account history stores.
> 
> Post-import, comment update watchers match startup: only the **ten newest** comments via **`getInitAccountCommentsToUpdate`**, not the full history.
> 
> **`addAccount`** gains stricter name-map handling (stale vacated names, missing metadata) and optional hydrated return without destroying the PKC instance. **`getDefaultAccountFields`** is shared between default account generation and import defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c2036fe38ab3949637aa73caca626febbf822e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Account imports now receive a fresh local identifier, preventing existing accounts from being overwritten.
  - Imported comments, votes, and edits are restored in bulk for faster handling of large backups.
  - Imported account history is available with its indexes and summaries intact.

- **Bug Fixes**
  - Account imports now preserve the original signer and author information.
  - Invalid vote or edit history is rejected before it can be saved.
  - Comment update monitoring is limited to the ten newest imported comments for improved efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->