### PR TITLE
chore(release): prepare 0.1.33

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.32",
+  "version": "0.1.33",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- bump `@bitsocial/bitsocial-react-hooks` from `0.1.32` to `0.1.33`
- trigger the master-only release workflow after merge

## Verification

- `corepack yarn install`
- `corepack yarn prettier`
- `corepack yarn build`
- `corepack yarn knip`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version-field change with no runtime or API impact.
> 
> **Overview**
> Bumps the published package version in `package.json` from **0.1.32** to **0.1.33** so the next merge to `master` can run the release workflow and publish `@bitsocial/bitsocial-react-hooks` at the new semver.
> 
> No library source, API, or dependency changes are included in this diff—only the version field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a1ce8da2ae671d36aec89d2d0d2b706750d4974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->