### PR TITLE
chore(release): prepare 0.1.34

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.33",
+  "version": "0.1.34",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
## Summary

- prepare `@bitsocial/bitsocial-react-hooks` version `0.1.34`
- let the existing master CI publish the package with provenance and create the matching GitHub release

## Verification

- `corepack yarn install`
- `corepack yarn build`
- `corepack yarn lint` (195 existing warnings, 0 errors)
- `corepack yarn type-check`
- `corepack yarn knip`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single version field change with no runtime or API impact; publish is handled by existing CI.
> 
> **Overview**
> Bumps **`@bitsocial/bitsocial-react-hooks`** from **0.1.33** to **0.1.34** in `package.json` as the release-prep step before master CI publishes the package (with provenance) and creates the matching GitHub release.
> 
> No library source, API, or dependency changes are included in this diff—only the semver version field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 41746e61fa1ad23d48db4bb267970510614fe6bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application version to 0.1.34.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->