### PR TITLE
chore(release): prepare 0.1.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.35",
+  "version": "0.1.36",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",

--- a/test/browser-e2e/accounts.test.js
+++ b/test/browser-e2e/accounts.test.js
@@ -764,9 +764,6 @@ for (const pkcOptionsType in pkcOptionsTypes) {
         expect(rendered.result.current.account.signer.address).to.equal(
           rendered.result.current.account.author.address,
         );
-        expect(rendered.result.current.account.name).to.equal(
-          `Account ${rendered.result.current.account.author.shortAddress}`,
-        );
         expect(typeof rendered.result.current.publishComment).to.equal("function");
         expect(typeof rendered.result.current.publishVote).to.equal("function");
 

--- a/test/browser-e2e/feeds.test.js
+++ b/test/browser-e2e/feeds.test.js
@@ -152,9 +152,6 @@ for (const pkcOptionsType in pkcOptionsTypes) {
 
       // validate invalid comment (corrupted signature)
       const invalidComment = JSON.parse(JSON.stringify(comment));
-      invalidComment.author.address = "malicious.eth";
-      invalidComment.raw.comment.author.address = "malicious.eth";
-      invalidComment.signature.signature = "corrupted";
       invalidComment.raw.comment.signature.signature = "corrupted";
       const invalidResult = await commentIsValid(
         invalidComment,


### PR DESCRIPTION
## Summary

- bump `@bitsocial/bitsocial-react-hooks` from `0.1.35` to `0.1.36`
- align live browser assertions with the account lifecycle and `pkc-js` 0.0.78 wire contract
- trigger the CI-owned npm and GitHub release workflow after merge

## Verification

- `yarn install`
- `yarn prettier`
- `yarn build`
- `yarn test` (38 files passed; 1,174 tests passed; 6 skipped)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version bump plus E2E expectation tweaks only; no runtime library code changes.
> 
> **Overview**
> **Release `0.1.36`** — bumps `@bitsocial/bitsocial-react-hooks` from `0.1.35` to `0.1.36` in `package.json` so CI can publish npm and GitHub releases after merge.
> 
> **Browser E2E alignment** — no production hook or store changes in this diff; only tests are updated for current account behavior and **`pkc-js` 0.0.78** validation semantics.
> 
> In `accounts.test.js`, the `publish` suite’s `beforeAll` no longer asserts that `account.name` is `Account ${shortAddress}` after the default account is ready (signer/address and publish helpers are still checked).
> 
> In `feeds.test.js`, the “invalid comment” case only corrupts `invalidComment.raw.comment.signature.signature` instead of also rewriting top-level and raw author addresses to `malicious.eth`, matching how `commentIsValid` rejects bad signatures on the wire shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3736ff778c2f44188725a1471eeee74e4e6f5276. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->