### PR TITLE
chore(release): prepare 0.1.38

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "version": "0.1.37",
+  "version": "0.1.38",
   "packageManager": "yarn@4.13.0",
   "files": [
     "CHANGELOG.md",


### PR DESCRIPTION
## Summary
- bump `@bitsocial/bitsocial-react-hooks` to `0.1.38`
- publish the merged crosspost helpers and hooks from rebuilt release artifacts

## Verification
- `corepack yarn install --immutable`
- `corepack yarn prettier`
- `corepack yarn type-check`
- `corepack yarn lint` (existing warnings only)
- `corepack yarn build`
- `corepack yarn test src/lib/crosspost.test.ts src/hooks/comments.test.ts` (61/61)
- `npm pack --dry-run --json` reports version `0.1.38` and includes rebuilt crosspost exports

No push outside this release branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only metadata change with no runtime, auth, or data-handling code modified.
> 
> **Overview**
> Bumps `@bitsocial/bitsocial-react-hooks` from `0.1.37` to `0.1.38` in `package.json` so the next publish can ship already-merged work (including crosspost helpers/hooks) under the new version.
> 
> No other source, changelog, or dependency changes are in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2b76b6643f13e4462295fd6dbdb0416ce4c352c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->